### PR TITLE
- Added a params method for combing an arbitrary number of `UPath`s

### DIFF
--- a/src/Zio.Tests/TestUPath.cs
+++ b/src/Zio.Tests/TestUPath.cs
@@ -117,6 +117,64 @@ namespace Zio.Tests
         }
 
         [Theory]
+        [InlineData("", "", "", "")]
+        [InlineData("a", "b", "c", "a/b/c")]
+        [InlineData("a/b", "c", "d", "a/b/c/d")]
+        [InlineData("", "b", "", "b")]
+        [InlineData("a", "", "", "a")]
+        [InlineData("a/b", "", "", "a/b")]
+        [InlineData("/a", "b/", "c/", "/a/b/c")]
+        [InlineData("/a", "/b", "/c", "/c")]
+        public void TestCombine3(string path1, string path2, string path3, string expectedResult)
+        {
+            var path = UPath.Combine(path1, path2, path3);
+            Assert.Equal(expectedResult, (string)path);
+
+            // Compare path info directly
+            var expectedPath = new UPath(expectedResult);
+            Assert.Equal(expectedPath, path);
+            Assert.Equal(expectedPath.GetHashCode(), path.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("", "", "", "", "")]
+        [InlineData("a", "b", "c", "d", "a/b/c/d")]
+        [InlineData("a/b", "c", "d/e", "f", "a/b/c/d/e/f")]
+        [InlineData("", "b", "", "", "b")]
+        [InlineData("a", "", "", "", "a")]
+        [InlineData("a/b", "", "", "", "a/b")]
+        [InlineData("/a", "b/", "c/", "", "/a/b/c")]
+        [InlineData("/a", "/b", "/c", "/d", "/d")]
+        [InlineData("a", "b", "..", "c", "a/c")]
+        public void TestCombine4(string path1, string path2, string path3, string path4, string expectedResult)
+        {
+            var path = UPath.Combine(path1, path2, path3, path4);
+            Assert.Equal(expectedResult, (string)path);
+
+            // Compare path info directly
+            var expectedPath = new UPath(expectedResult);
+            Assert.Equal(expectedPath, path);
+            Assert.Equal(expectedPath.GetHashCode(), path.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData(new[] { "", "" }, "")]
+        [InlineData(new[] { "a", "b", "c", "d", "e" }, "a/b/c/d/e")]
+        [InlineData(new[] { "a", "..", "c", "..", "e" }, "e")]
+        [InlineData(new[] { "a", "b", "c", "/d", "e" }, "/d/e")]
+        [InlineData(new[] { "a", "", "", "", "e" }, "a/e")]
+        public void TestCombineN(string[] parts, string expectedResult)
+        {
+            var path = UPath.Combine(parts.Select(a => (UPath)a).ToArray());
+            Assert.Equal(expectedResult, (string)path);
+
+            // Compare path info directly
+            var expectedPath = new UPath(expectedResult);
+            Assert.Equal(expectedPath, path);
+            Assert.Equal(expectedPath.GetHashCode(), path.GetHashCode());
+        }
+
+        [Theory]
         [InlineData("", "")]
         [InlineData("/", "")]
         [InlineData("/a", "a")]

--- a/src/Zio/UPath.cs
+++ b/src/Zio/UPath.cs
@@ -168,6 +168,26 @@ namespace Zio
             }
         }
 
+        public static UPath Combine(UPath path1, UPath path2, UPath path3)
+        {
+            return UPath.Combine(UPath.Combine(path1, path2), path3);
+        }
+
+        public static UPath Combine(UPath path1, UPath path2, UPath path3, UPath path4)
+        {
+            return UPath.Combine(Combine(path1, path2), Combine(path3, path4));
+        }
+
+        public static UPath Combine(params UPath[] paths)
+        {
+            var path = paths[0];
+
+            for (var i = 1; i < paths.Length; i++)
+                path = Combine(path, paths[i]);
+
+            return path;
+        }
+
         /// <summary>
         /// Implements the / operator equivalent of <see cref="Combine"/>
         /// </summary>


### PR DESCRIPTION
 - Added a params method for combing an arbitrary number of `UPath`s
   - Mirrors https://msdn.microsoft.com/en-us/library/dd991142(v=vs.110).aspx
 - Added explicit methods for the common cases of combining 3 and 4 paths (saves allocating a params array in these cases)
   - Mirrors https://msdn.microsoft.com/en-us/library/dd784047(v=vs.110).aspx and https://msdn.microsoft.com/en-us/library/dd782933(v=vs.110).aspx