### PR TITLE
Allow IFileSystem.Watch to return null if watching cannot be done

### DIFF
--- a/src/Zio/FileSystems/AggregateFileSystem.cs
+++ b/src/Zio/FileSystems/AggregateFileSystem.cs
@@ -94,7 +94,10 @@ namespace Zio.FileSystems
                     foreach (var watcher in _watchers)
                     {
                         var newWatcher = fileSystem.Watch(watcher.Path);
-                        watcher.Add(newWatcher);
+                        if (newWatcher != null)
+                        {
+                            watcher.Add(newWatcher);
+                        }
                     }
                 }
             }
@@ -122,7 +125,10 @@ namespace Zio.FileSystems
                     foreach (var watcher in _watchers)
                     {
                         var newWatcher = fs.Watch(watcher.Path);
-                        watcher.Add(newWatcher);
+                        if (newWatcher != null)
+                        {
+                            watcher.Add(newWatcher);
+                        }
                     }
                 }
                 else
@@ -374,12 +380,20 @@ namespace Zio.FileSystems
 
                 if (NextFileSystem != null)
                 {
-                    watcher.Add(NextFileSystem.Watch(path));
+                    var newWatcher = NextFileSystem.Watch(path);
+                    if (newWatcher != null)
+                    {
+                        watcher.Add(newWatcher);
+                    }
                 }
 
                 foreach (var fs in _fileSystems)
                 {
-                    watcher.Add(fs.Watch(path));
+                    var newWatcher = fs.Watch(path);
+                    if (newWatcher != null)
+                    {
+                        watcher.Add(newWatcher);
+                    }
                 }
 
                 _watchers.Add(watcher);

--- a/src/Zio/FileSystems/FileSystemEventDispatcher.cs
+++ b/src/Zio/FileSystems/FileSystemEventDispatcher.cs
@@ -79,6 +79,11 @@ namespace Zio.FileSystems
         /// <param name="watcher">Instance to add.</param>
         public void Add(T watcher)
         {
+            if (watcher == null)
+            {
+                throw new ArgumentNullException(nameof(watcher));
+            }
+
             lock (_watchers)
             {
                 _watchers.Add(watcher);
@@ -91,6 +96,11 @@ namespace Zio.FileSystems
         /// <param name="watcher">Instance to remove.</param>
         public void Remove(T watcher)
         {
+            if (watcher == null)
+            {
+                throw new ArgumentNullException(nameof(watcher));
+            }
+
             lock (_watchers)
             {
                 _watchers.Remove(watcher);

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -72,7 +72,10 @@ namespace Zio.FileSystems
                     foreach (var watcher in _aggregateWatchers)
                     {
                         var internalWatcher = fileSystem.Watch(UPath.Root);
-                        watcher.Add(new Watcher(this, name, UPath.Root, internalWatcher));
+                        if (internalWatcher != null)
+                        {
+                            watcher.Add(new Watcher(this, name, UPath.Root, internalWatcher));
+                        }
                     }
                 }
             }
@@ -614,13 +617,19 @@ namespace Zio.FileSystems
                     foreach (var kvp in _mounts)
                     {
                         var internalWatcher = kvp.Value.Watch(UPath.Root);
-                        watcher.Add(new Watcher(this, kvp.Key, UPath.Root, internalWatcher));
+                        if (internalWatcher != null)
+                        {
+                            watcher.Add(new Watcher(this, kvp.Key, UPath.Root, internalWatcher));
+                        }
                     }
 
                     if (NextFileSystem != null)
                     {
                         var internalWatcher = NextFileSystem.Watch(UPath.Root);
-                        watcher.Add(new Watcher(this, null, UPath.Root, internalWatcher));
+                        if (internalWatcher != null)
+                        {
+                            watcher.Add(new Watcher(this, null, UPath.Root, internalWatcher));
+                        }
                     }
 
                     _aggregateWatchers.Add(watcher);
@@ -639,6 +648,11 @@ namespace Zio.FileSystems
                 }
 
                 var internalWatcher = fs.Watch(internalPath);
+                if (internalWatcher == null)
+                {
+                    return null;
+                }
+
                 var watcher = new Watcher(this, mountPath, path, internalWatcher);
 
                 lock (_watchers)

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -188,7 +188,7 @@ namespace Zio
         /// configured before events are called.
         /// </summary>
         /// <param name="path">The path to watch for changes.</param>
-        /// <returns>An <see cref="IFileSystemWatcher"/> instance that watches the given path.</returns>
+        /// <returns>An <see cref="IFileSystemWatcher"/> instance that watches the given path, or <c>null</c> if the filesystem cannot be watched.</returns>
         IFileSystemWatcher Watch(UPath path);
 
         // ----------------------------------------------


### PR DESCRIPTION
For #12.

Not all filesystems will be able to support watching (likely read-only) but throwing an exception prevents watching of composed filesystems such as an aggregate of a physical path and some other read-only filesystems.