### PR TITLE
Fix AggregateFileSystemWatcher watchers not being in sync

### DIFF
--- a/src/Zio/FileSystems/AggregateFileSystemWatcher.cs
+++ b/src/Zio/FileSystems/AggregateFileSystemWatcher.cs
@@ -44,6 +44,12 @@ namespace Zio.FileSystems
                     throw new ArgumentException("The filesystem watcher is already added", nameof(watcher));
                 }
 
+                watcher.InternalBufferSize = InternalBufferSize;
+                watcher.NotifyFilter = NotifyFilter;
+                watcher.EnableRaisingEvents = EnableRaisingEvents;
+                watcher.IncludeSubdirectories = IncludeSubdirectories;
+                watcher.Filter = Filter;
+
                 RegisterEvents(watcher);
                 _children.Add(watcher);
             }


### PR DESCRIPTION
If a watcher is added the the aggregate after `Watch` is called, such as when adding a filesystem to a `MountFileSystem` or `AggregateFileSystem`, it will not copy over the required configuration and wont raise events. 
  