### PR TITLE
Add IFileSystem.CanWatch

### DIFF
--- a/src/Zio/FileSystemExtensions.cs
+++ b/src/Zio/FileSystemExtensions.cs
@@ -718,7 +718,7 @@ namespace Zio
         }
 
         /// <summary>
-        /// Gets a <see cref="FileSystemEntry"/> for the specified path. If the file or directory does no exist, throws a <see cref="FileNotFoundException"/>
+        /// Gets a <see cref="FileSystemEntry"/> for the specified path. If the file or directory does not exist, throws a <see cref="FileNotFoundException"/>
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The file or directory path.</param>
@@ -740,7 +740,7 @@ namespace Zio
         }
 
         /// <summary>
-        /// Tries to get a <see cref="FileSystemEntry"/> for the specified path. If the file or directory does no exist, returns null.
+        /// Tries to get a <see cref="FileSystemEntry"/> for the specified path. If the file or directory does not exist, returns null.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The file or directory path.</param>
@@ -762,7 +762,7 @@ namespace Zio
         }
 
         /// <summary>
-        /// Gets a <see cref="FileEntry"/> for the specified path. If the file does no exist, throws a <see cref="FileNotFoundException"/>
+        /// Gets a <see cref="FileEntry"/> for the specified path. If the file does not exist, throws a <see cref="FileNotFoundException"/>
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="filePath">The file path.</param>
@@ -777,7 +777,7 @@ namespace Zio
         }
 
         /// <summary>
-        /// Gets a <see cref="DirectoryEntry"/> for the specified path. If the file does no exist, throws a <see cref="DirectoryNotFoundException"/>
+        /// Gets a <see cref="DirectoryEntry"/> for the specified path. If the file does not exist, throws a <see cref="DirectoryNotFoundException"/>
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="directoryPath">The directory path.</param>
@@ -789,6 +789,22 @@ namespace Zio
                 throw NewDirectoryNotFoundException(directoryPath);
             }
             return new DirectoryEntry(fileSystem, directoryPath);
+        }
+
+        /// <summary>
+        /// Tries to watch the specified path. If watching the file system or path is not supported, returns null.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="path">The path to watch for changes.</param>
+        /// <returns>An <see cref="IFileSystemWatcher"/> instance or null if not supported.</returns>
+        public static IFileSystemWatcher TryWatch(this IFileSystem fileSystem, UPath path)
+        {
+            if (!fileSystem.CanWatch(path))
+            {
+                return null;
+            }
+
+            return fileSystem.Watch(path);
         }
     }
 }

--- a/src/Zio/FileSystems/AggregateFileSystem.cs
+++ b/src/Zio/FileSystems/AggregateFileSystem.cs
@@ -93,8 +93,11 @@ namespace Zio.FileSystems
 
                     foreach (var watcher in _watchers)
                     {
-                        var newWatcher = fileSystem.Watch(watcher.Path);
-                        watcher.Add(newWatcher);
+                        if (fileSystem.CanWatch(watcher.Path))
+                        {
+                            var newWatcher = fileSystem.Watch(watcher.Path);
+                            watcher.Add(newWatcher);
+                        }
                     }
                 }
             }
@@ -121,8 +124,11 @@ namespace Zio.FileSystems
 
                     foreach (var watcher in _watchers)
                     {
-                        var newWatcher = fs.Watch(watcher.Path);
-                        watcher.Add(newWatcher);
+                        if (fs.CanWatch(watcher.Path))
+                        {
+                            var newWatcher = fs.Watch(watcher.Path);
+                            watcher.Add(newWatcher);
+                        }
                     }
                 }
                 else
@@ -372,14 +378,17 @@ namespace Zio.FileSystems
             {
                 var watcher = new AggregateFileSystemWatcher(this, path);
 
-                if (NextFileSystem != null)
+                if (NextFileSystem != null && NextFileSystem.CanWatch(path))
                 {
                     watcher.Add(NextFileSystem.Watch(path));
                 }
 
                 foreach (var fs in _fileSystems)
                 {
-                    watcher.Add(fs.Watch(path));
+                    if (fs.CanWatch(path))
+                    {
+                        watcher.Add(fs.Watch(path));
+                    }
                 }
 
                 _watchers.Add(watcher);

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -439,18 +439,45 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
+        public bool CanWatch(UPath path)
+        {
+            AssertNotDisposed();
+            return CanWatchImpl(ValidatePath(path));
+        }
+
+        /// <summary>
+        /// Implementation for <see cref="CanWatch"/>, <paramref name="path"/> is guaranteed to be absolute and validated through <see cref="ValidatePath"/>.
+        /// Checks if the file system and <paramref name="path"/> can be watched with <see cref="Watch"/>.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if the the path can be watched on this file system.</returns>
+        protected virtual bool CanWatchImpl(UPath path)
+        {
+            return true;
+        }
+
+        /// <inheritdoc />
         public IFileSystemWatcher Watch(UPath path)
         {
             AssertNotDisposed();
-            return WatchImpl(ValidatePath(path));
+
+            var validatedPath = ValidatePath(path);
+
+            if (!CanWatchImpl(validatedPath))
+            {
+                throw new NotSupportedException($"The file system or path `{validatedPath}` does not support watching");
+            }
+
+            return WatchImpl(validatedPath);
         }
 
         /// <summary>
         /// Implementation for <see cref="Watch"/>, <paramref name="path"/> is guaranteed to be absolute and valudated through <see cref="ValidatePath"/>.
-        /// Returns an <see cref="IFileSystemWatcher"/> instance that can be used to watch for changes to files and directories in the given path.
+        /// Returns an <see cref="IFileSystemWatcher"/> instance that can be used to watch for changes to files and directories in the given path. The instance must be
+        /// configured before events are raised.
         /// </summary>
         /// <param name="path">The path to watch for changes.</param>
-        /// <returns>An <see cref="IFileSystemWatcher"/> instance that can be used to watch for changes.</returns>
+        /// <returns>An <see cref="IFileSystemWatcher"/> instance that watches the given path.</returns>
         protected abstract IFileSystemWatcher WatchImpl(UPath path);
 
         // ----------------------------------------------

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -74,8 +74,11 @@ namespace Zio.FileSystems
                             continue;
                         }
 
-                        var internalWatcher = fileSystem.Watch(remainingPath);
-                        watcher.Add(new Watcher(this, name, remainingPath, internalWatcher));
+                        if (fileSystem.CanWatch(remainingPath))
+                        {
+                            var internalWatcher = fileSystem.Watch(remainingPath);
+                            watcher.Add(new Watcher(this, name, remainingPath, internalWatcher));
+                        }
                     }
                 }
             }
@@ -603,12 +606,15 @@ namespace Zio.FileSystems
                     {
                         continue;
                     }
-                    
-                    var internalWatcher = kvp.Value.Watch(remainingPath);
-                    watcher.Add(new Watcher(this, kvp.Key, remainingPath, internalWatcher));
+
+                    if (kvp.Value.CanWatch(remainingPath))
+                    {
+                        var internalWatcher = kvp.Value.Watch(remainingPath);
+                        watcher.Add(new Watcher(this, kvp.Key, remainingPath, internalWatcher));
+                    }
                 }
 
-                if (NextFileSystem != null)
+                if (NextFileSystem != null && NextFileSystem.CanWatch(path))
                 {
                     var internalWatcher = NextFileSystem.Watch(path);
                     watcher.Add(new Watcher(this, null, path, internalWatcher));

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -184,8 +184,15 @@ namespace Zio
         // ----------------------------------------------
 
         /// <summary>
+        /// Checks if the file system and <paramref name="path"/> can be watched with <see cref="Watch"/>.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if the the path can be watched on this file system.</returns>
+        bool CanWatch(UPath path);
+
+        /// <summary>
         /// Returns an <see cref="IFileSystemWatcher"/> instance that can be used to watch for changes to files and directories in the given path. The instance must be
-        /// configured before events are called.
+        /// configured before events are raised.
         /// </summary>
         /// <param name="path">The path to watch for changes.</param>
         /// <returns>An <see cref="IFileSystemWatcher"/> instance that watches the given path.</returns>


### PR DESCRIPTION
For #12.

This isn't complete yet. Waiting for #13 to be resolved because the remaining changes need to update the (currently broken) watch logic in `MountFileSystem`.