### PR TITLE
Dispose inner filesystems when disposing a composable filesystem

### DIFF
--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -13,13 +13,25 @@ namespace Zio.FileSystems
     /// </summary>
     public abstract class ComposeFileSystem : FileSystem
     {
+        protected bool Owned { get; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ComposeFileSystem"/> class.
         /// </summary>
         /// <param name="fileSystem">The delegated file system (can be null).</param>
-        protected ComposeFileSystem(IFileSystem fileSystem)
+        /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
+        protected ComposeFileSystem(IFileSystem fileSystem, bool owned = true)
         {
             NextFileSystem = fileSystem;
+            Owned = owned;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && Owned)
+            {
+                NextFileSystem?.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -155,8 +155,9 @@ namespace Zio.FileSystems
         /// Unmounts the specified mount name and its attached filesystem.
         /// </summary>
         /// <param name="name">The mount name.</param>
+        /// <returns>The filesystem that was unmounted.</returns>
         /// <exception cref="System.ArgumentException">The mount with the name <paramref name="name"/> was not found</exception>
-        public void Unmount(UPath name)
+        public IFileSystem Unmount(UPath name)
         {
             AssertMountName(name);
 
@@ -179,6 +180,8 @@ namespace Zio.FileSystems
                     watcher.RemoveFrom(mountFileSystem);
                 }
             }
+
+            return mountFileSystem;
         }
 
         /// <inheritdoc />

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -22,7 +22,8 @@ namespace Zio.FileSystems
         /// <summary>
         /// Initializes a new instance of the <see cref="MountFileSystem"/> class.
         /// </summary>
-        public MountFileSystem() : this(null)
+        /// <param name="owned">True if mounted filesystems should be disposed when this instance is disposed.</param>
+        public MountFileSystem(bool owned = true) : this(null, owned)
         {
         }
 
@@ -30,10 +31,44 @@ namespace Zio.FileSystems
         /// Initializes a new instance of the <see cref="MountFileSystem"/> class with a default backup filesystem.
         /// </summary>
         /// <param name="defaultBackupFileSystem">The default backup file system.</param>
-        public MountFileSystem(IFileSystem defaultBackupFileSystem) : base(defaultBackupFileSystem)
+        /// <param name="owned">True if <paramref name="defaultBackupFileSystem"/> and mounted filesytems should be disposed when this instance is disposed.</param>
+        public MountFileSystem(IFileSystem defaultBackupFileSystem, bool owned = true) : base(defaultBackupFileSystem, owned)
         {
             _mounts = new SortedList<UPath, IFileSystem>(new UPathLengthComparer());
             _aggregateWatchers = new List<AggregateFileSystemWatcher>();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing)
+            {
+                return;
+            }
+
+            lock (_mounts)
+            {
+                if (Owned)
+                {
+                    foreach (var kvp in _mounts)
+                    {
+                        kvp.Value.Dispose();
+                    }
+                }
+
+                _mounts.Clear();
+            }
+
+            lock (_aggregateWatchers)
+            {
+                foreach (var watcher in _aggregateWatchers)
+                {
+                    watcher.Dispose();
+                }
+
+                _aggregateWatchers.Clear();
+            }
         }
 
         /// <summary>

--- a/src/Zio/FileSystems/ReadOnlyFileSystem.cs
+++ b/src/Zio/FileSystems/ReadOnlyFileSystem.cs
@@ -22,7 +22,8 @@ namespace Zio.FileSystems
         /// Initializes a new instance of the <see cref="ReadOnlyFileSystem"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
-        public ReadOnlyFileSystem(IFileSystem fileSystem) : base(fileSystem)
+        /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
+        public ReadOnlyFileSystem(IFileSystem fileSystem, bool owned = true) : base(fileSystem, owned)
         {
         }
 

--- a/src/Zio/FileSystems/SubFileSystem.cs
+++ b/src/Zio/FileSystems/SubFileSystem.cs
@@ -17,8 +17,9 @@ namespace Zio.FileSystems
         /// </summary>
         /// <param name="fileSystem">The file system to create a view from.</param>
         /// <param name="subPath">The sub path view to create filesystem.</param>
+        /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
         /// <exception cref="DirectoryNotFoundException">If the directory subPath does not exist in the delegate FileSystem</exception>
-        public SubFileSystem(IFileSystem fileSystem, UPath subPath) : base(fileSystem)
+        public SubFileSystem(IFileSystem fileSystem, UPath subPath, bool owned = true) : base(fileSystem, owned)
         {
             SubPath = subPath.AssertAbsolute(nameof(subPath));
             if (!fileSystem.DirectoryExists(SubPath))


### PR DESCRIPTION
Only happens if the `owned` constructor parameter (optional, default true) is set to true.

Also changed `MountFileSystem.Unmount` to return the filesystem it unmounted. This will help users dispose of the instances by removing the need to keep track of what was mounted.

For #19.