### PR TITLE
Remove SearchPattern special case for Windows

### DIFF
--- a/src/Zio.Tests/TestSearchPattern.cs
+++ b/src/Zio.Tests/TestSearchPattern.cs
@@ -49,7 +49,7 @@ namespace Zio.Tests
         [InlineData("/a/b/c", "x*.txt", "xyoyo.txt", true)]
         [InlineData("/a/b/c", "x*.txt", "x.txt", true)]
         [InlineData("/a/b/c", "*.txt", "x.txt", true)]
-        [InlineData("/a/b/c", "*.txt", "x.txt1", true)]
+        [InlineData("/a/b/c", "*.txt", "x.txt1", false)] // No 8.3 truncating
         [InlineData("/a/b/c", "*.i", "x.i", true)]
         [InlineData("/a/b/c", "*.i", "x.i1", false)]
         [InlineData("/a/b/c", "x*.txt", "x_txt", false)]

--- a/src/Zio/SearchPattern.cs
+++ b/src/Zio/SearchPattern.cs
@@ -104,7 +104,6 @@ namespace Zio
                 }
             }
 
-            bool appendSpecialCaseForExt3Chars = false;
             var startIndex = 0;
             int nextIndex;
             StringBuilder builder = null;
@@ -129,16 +128,6 @@ namespace Zio
                     var regexPatternPart = c == '*' ? "[^/]*" : "[^/]";
                     builder.Append(regexPatternPart);
 
-                    // If the specified extension is exactly three characters long, 
-                    // the method returns files with extensions that begin with the specified extension. 
-                    // For example, "*.xls" returns both "book.xls" and "book.xlsx".
-                    // 012345
-                    // *.txt
-                    if (c == '*' && nextIndex + 5 == searchPattern.Length && searchPattern[nextIndex + 1] == '.' && searchPattern.IndexOf('.', nextIndex + 2) < 0)
-                    {
-                        appendSpecialCaseForExt3Chars = true;
-                    }
-
                     startIndex = nextIndex + 1;
                 }
                 if (builder == null)
@@ -152,11 +141,6 @@ namespace Zio
                     {
                         var toEscape = Regex.Escape(searchPattern.Substring(startIndex, length));
                         builder.Append(toEscape);
-                    }
-
-                    if (appendSpecialCaseForExt3Chars)
-                    {
-                        builder.Append("[^/]*");
                     }
 
                     builder.Append("$");


### PR DESCRIPTION
Fix for #10. Windows can return files that don't match the given search pattern in `EnumeratePaths` because 8.3 naming (from DOS) is enabled for the filesystem.

This removes the special case allowing those names to pass `SearchPattern` tests and makes sure the returned paths match the search pattern on Windows.