### PR TITLE
Add CanWatch impls to physical and composite FS

### DIFF
--- a/src/Zio/FileSystems/AggregateFileSystem.cs
+++ b/src/Zio/FileSystems/AggregateFileSystem.cs
@@ -407,6 +407,13 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
+        protected override bool CanWatchImpl(UPath path)
+        {
+            // Always allow watching because a future filesystem can be added that matches this path.
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override IFileSystemWatcher WatchImpl(UPath path)
         {
             lock (_fileSystems)

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -197,6 +197,12 @@ namespace Zio.FileSystems
         // ----------------------------------------------
         // Watch API
         // ----------------------------------------------
+        
+        /// <inheritdoc />
+        protected override bool CanWatchImpl(UPath path)
+        {
+            return NextFileSystemSafe.CanWatch(ConvertPathToDelegate(path));
+        }
 
         /// <inheritdoc />
         protected override IFileSystemWatcher WatchImpl(UPath path)

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -628,6 +628,13 @@ namespace Zio.FileSystems
         }
 
         /// <inheritdoc />
+        protected override bool CanWatchImpl(UPath path)
+        {
+            // Always allow watching because a future filesystem can be added that matches this path.
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override IFileSystemWatcher WatchImpl(UPath path)
         {
             // TODO: create/delete events when mounts are added/removed

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -510,6 +510,17 @@ namespace Zio.FileSystems
         // ----------------------------------------------
         // Watch API
         // ----------------------------------------------
+        
+        /// <inheritdoc />
+        protected override bool CanWatchImpl(UPath path)
+        {
+            if (IsWithinSpecialDirectory(path))
+            {
+                return SpecialDirectoryExists(path);
+            }
+
+            return Directory.Exists(ConvertPathToInternal(path));
+        }
 
         /// <inheritdoc />
         protected override IFileSystemWatcher WatchImpl(UPath path)


### PR DESCRIPTION
`System.IO.FileSystemWatcher` throws if the directory to watch doesn't exist. The `ComposeFileSystem`s were missing implementations for `CanWatch` as well.