### PR TITLE
Don't throw when enumerating root on empty MountFS

### DIFF
--- a/src/Zio.Tests/FileSystems/TestMountFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestMountFileSystem.cs
@@ -221,6 +221,30 @@ namespace Zio.Tests.FileSystems
         }
 
         [Fact]
+        public void EnumerateEmptyOnRoot()
+        {
+            var mountFs = new MountFileSystem();
+            var expected = Array.Empty<UPath>();
+            var actual = mountFs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void EnumerateDoesntExist()
+        {
+            var mountFs = new MountFileSystem();
+            mountFs.Mount("/x", new MemoryFileSystem());
+            Assert.Throws<DirectoryNotFoundException>(() => mountFs.EnumeratePaths("/y", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList());
+        }
+
+        [Fact]
+        public void EnumerateBackupDoesntExist()
+        {
+            var mountFs = new MountFileSystem(new MemoryFileSystem());            
+            Assert.Throws<DirectoryNotFoundException>(() => mountFs.EnumeratePaths("/y", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList());
+        }
+
+        [Fact]
         public void DirectoryExistsPartialMountName()
         {
             var fs = new MemoryFileSystem();

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -657,7 +657,7 @@ namespace Zio.FileSystems
 
                 if (first)
                 {
-                    if (locations.Count == 0)
+                    if (locations.Count == 0 && path != UPath.Root)
                         throw NewDirectoryNotFoundException(path);
 
                     first = false;


### PR DESCRIPTION
Root should be assumed to exist so it should not be throwing