### PR TITLE
Fix IFileSystemWatcher instances not being removed from AggregateFSWs

### DIFF
--- a/src/Zio/FileSystems/AggregateFileSystemWatcher.cs
+++ b/src/Zio/FileSystems/AggregateFileSystemWatcher.cs
@@ -77,7 +77,7 @@ namespace Zio.FileSystems
                     }
                     
                     UnregisterEvents(watcher);
-                    _children.Remove(watcher);
+                    _children.RemoveAt(i);
                     watcher.Dispose();
                 }
             }
@@ -100,7 +100,7 @@ namespace Zio.FileSystems
                     }
 
                     UnregisterEvents(watcher);
-                    _children.Remove(watcher);
+                    _children.RemoveAt(i);
                     watcher.Dispose();
                 }
             }


### PR DESCRIPTION
The watchers had `FileSystem` set to the `MountFileSystem` and removal was checking for the internal `IFileSystem` being watched. Those are never going to be the same so the instances were never removed.

I noticed this when I had a `PhysicalFileSystem` mounted, watched the `MountFileSystem`, then remove (and dispose) the physical FS instance. When the watcher picks something up it'll throw an `ObjectDisposedException` trying to use the `PhysicalFileSystem` instance.

I also moved the removal (and disposal) of those FSWs to happen before FS disposal could happen to avoid a similar disposal issue.