### PR TITLE
Fix PhysicalFileSystem on .NET Framework 4.*

### DIFF
--- a/src/Zio.Tests/Zio.Tests.csproj
+++ b/src/Zio.Tests/Zio.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>net5.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -619,7 +619,7 @@ namespace Zio.FileSystems
                     CreationTime = fileInfo.CreationTimeUtc.ToLocalTime(),
                     LastAccessTime = fileInfo.LastAccessTimeUtc.ToLocalTime(),
                     LastWriteTime = fileInfo.LastWriteTimeUtc.ToLocalTime(),
-                    Length = fileInfo.Length
+                    Length = (fileInfo.Attributes & FileAttributes.Directory) > 0 ? 0 : fileInfo.Length
                 };
                 if (searchPredicate == null || searchPredicate(ref item))
                 {


### PR DESCRIPTION
Attempting to use `PhysicalFileSystem.EnumerateItems` on .NET Framework 4.7.2 will throw a `FileNotFoundException`. This is caused by attempting to read `FileInfo.Length` on directories. This pull requests fixes the issue, and enables the `Zio.Tests` project for .NET Framework 4.7.2 to catch similar issues in the future.