### PR TITLE
Conversion to async

### DIFF
--- a/src/Zio.Tests/FileSystems/TestFileSystemBase.cs
+++ b/src/Zio.Tests/FileSystems/TestFileSystemBase.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Zio.FileSystems;
 
@@ -15,9 +16,9 @@ namespace Zio.Tests.FileSystems
     {
         private static readonly UPath[] Directories = new UPath[] { "a", "b", "C", "d" };
         private static readonly UPath[] Files = new UPath[] { "b.txt", "c.txt1", "d.i", "f.i1", "A.txt", "a/a1.txt", "b/b.i", "E" };
-        private static readonly object Lock = new object();
         private PhysicalDirectoryHelper _physicalDirectoryHelper;
         private readonly EnumeratePathsResult _referenceEnumeratePathsResult;
+        private static readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
 
 
         // -------------------------------------
@@ -54,10 +55,12 @@ namespace Zio.Tests.FileSystems
             IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
             // Use a static lock to make sure a single process is running
-            // as we may have changed on the disk that may interact with other tests
-            Monitor.Enter(Lock);
+            // as we may have changed on the disk that may interact with other tests.
+            // SemaphoreSlim because it doesn't require the releasing thread to be the same.
 
-            _referenceEnumeratePathsResult = new EnumeratePathsResult(GetCommonPhysicalFileSystem());
+            Lock.Wait();
+
+            _referenceEnumeratePathsResult = EnumeratePathsResult.Create(GetCommonPhysicalFileSystem().GetAwaiter().GetResult()).GetAwaiter().GetResult();
         }
 
         public string SystemPath { get; }
@@ -93,38 +96,39 @@ namespace Zio.Tests.FileSystems
 
         public virtual void Dispose()
         {
-            if (_physicalDirectoryHelper != null)
+            try
             {
-                _physicalDirectoryHelper.Dispose();
-            }
+                if (_physicalDirectoryHelper != null)
+                {
+                    _physicalDirectoryHelper.Dispose();
+                }
 
-            Monitor.Exit(Lock);
+                
+            }
+            finally
+            {
+                Lock.Release();
+            }
         }
 
-
-        protected IFileSystem GetCommonPhysicalFileSystem()
+        protected async ValueTask<IFileSystem> GetCommonPhysicalFileSystem()
         {
             if (_physicalDirectoryHelper == null)
             {
-                _physicalDirectoryHelper = new PhysicalDirectoryHelper(SystemPath);
-                CreateFolderStructure(_physicalDirectoryHelper.PhysicalFileSystem);
+                _physicalDirectoryHelper = await PhysicalDirectoryHelper.Create(SystemPath);
+                await CreateFolderStructure(_physicalDirectoryHelper.PhysicalFileSystem);
             }
             return _physicalDirectoryHelper.PhysicalFileSystem;
         }
 
-        protected MemoryFileSystem GetCommonMemoryFileSystem()
+        protected async ValueTask<MemoryFileSystem> GetCommonMemoryFileSystem()
         {
             var fs = new MemoryFileSystem();
-            CreateFolderStructure(fs);
+            await CreateFolderStructure(fs);
             return fs;
         }
 
-        protected AggregateFileSystem GetCommonAggregateFileSystem()
-        {
-            return GetCommonAggregateFileSystem(out _, out _, out _);
-        }
-
-        protected AggregateFileSystem GetCommonAggregateFileSystem(out MemoryFileSystem fs1, out MemoryFileSystem fs2, out MemoryFileSystem fs3)
+        protected async ValueTask<(AggregateFileSystem aggregate, MemoryFileSystem fs1, MemoryFileSystem fs2, MemoryFileSystem fs3)> GetCommonAggregateFileSystem()
         {
             // ----------------------------------------------
             // This creates the following AggregateFileSystem
@@ -154,51 +158,51 @@ namespace Zio.Tests.FileSystems
             // f.i1               -> fs3
             // E                  -> fs2
 
-            fs1 = new MemoryFileSystem() {Name = "mem0"};
-            CreateFolderStructure(fs1);
-            fs2 = fs1.Clone();
+            MemoryFileSystem fs1 = new MemoryFileSystem() {Name = "mem0"};
+            await CreateFolderStructure(fs1);
+            MemoryFileSystem fs2 = fs1.Clone();
             fs2.Name = "mem1";
-            fs3 = fs2.Clone();
+            MemoryFileSystem fs3 = fs2.Clone();
             fs3.Name = "mem2";
 
             // Delete part of fs2 so that it will fallback to fs1
-            fs2.DeleteDirectory("/a/a", true);
-            fs2.DeleteDirectory("/a/b", true);
-            fs2.DeleteDirectory("/b", true);
+            await fs2.DeleteDirectory("/a/a", true);
+            await fs2.DeleteDirectory("/a/b", true);
+            await fs2.DeleteDirectory("/b", true);
 
             // Delete on fs3 to fallback to fs2 and fs1
-            fs3.DeleteDirectory("/a", true);
-            fs3.DeleteDirectory("/C", true);
-            fs3.DeleteFile("/b.txt");
-            fs3.DeleteFile("/E");
+            await fs3.DeleteDirectory("/a", true);
+            await fs3.DeleteDirectory("/C", true);
+            await fs3.DeleteFile("/b.txt");
+            await fs3.DeleteFile("/E");
 
             var aggfs = new AggregateFileSystem(fs1);
             aggfs.AddFileSystem(fs2);
             aggfs.AddFileSystem(fs3);
 
-            return aggfs;
+            return (aggfs, fs1, fs2, fs3);
         }
 
-        protected MountFileSystem GetCommonMountFileSystemWithOnlyBackup()
+        protected async ValueTask<MountFileSystem> GetCommonMountFileSystemWithOnlyBackup()
         {
             // Check on MountFileSystem directly with backup mount
             var fs = new MemoryFileSystem();
-            CreateFolderStructure(fs);
+            await CreateFolderStructure(fs);
             var mountfs = new MountFileSystem(fs);
             return mountfs;
         }
 
-        protected MountFileSystem GetCommonMountFileSystemWithMounts()
+        protected async ValueTask<MountFileSystem> GetCommonMountFileSystemWithMounts()
         {
             // Check on MountFileSystem
             // with real mount
             var fs = new MemoryFileSystem();
-            CreateFolderStructure(fs);
-            fs.DeleteDirectory("/b", true);
-            fs.DeleteDirectory("/C", true);
+            await CreateFolderStructure(fs);
+            await fs.DeleteDirectory("/b", true);
+            await fs.DeleteDirectory("/C", true);
 
             var fs1 = new MemoryFileSystem();
-            fs1.WriteAllText("/b.i", "content");
+            await fs1.WriteAllText("/b.i", "content");
 
             var mountfs = new MountFileSystem(fs);
             mountfs.Mount("/b", fs1);
@@ -207,31 +211,31 @@ namespace Zio.Tests.FileSystems
             return mountfs;
         }
 
-        protected void AssertCommonReadOnly(IFileSystem fs)
+        protected async ValueTask AssertCommonReadOnly(IFileSystem fs)
         {
-            Assert.True(fs.DirectoryExists("/"));
+            Assert.True(await fs.DirectoryExists("/"));
 
-            Assert.Throws<IOException>(() => fs.CreateDirectory("/test"));
-            Assert.Throws<IOException>(() => fs.DeleteDirectory("/test", true));
-            Assert.Throws<IOException>(() => fs.MoveDirectory("/drive", "/drive2"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CreateDirectory("/test"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.DeleteDirectory("/test", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveDirectory("/drive", "/drive2"));
 
-            Assert.Throws<IOException>(() => fs.CreateFile("/toto.txt"));
-            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/dest.txt", true));
-            Assert.Throws<IOException>(() => fs.MoveFile("/drive", "/drive2"));
-            Assert.Throws<IOException>(() => fs.DeleteFile("/toto.txt"));
-            Assert.Throws<IOException>(() => fs.OpenFile("/toto.txt", FileMode.Create, FileAccess.ReadWrite));
-            Assert.Throws<IOException>(() => fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Write));
-            Assert.Throws<IOException>(() => fs.ReplaceFile("/a/a/a1.txt", "/A.txt", "/titi.txt", true));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.CreateFile("/toto.txt"));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.CopyFile("/toto.txt", "/dest.txt", true));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.MoveFile("/drive", "/drive2"));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.DeleteFile("/toto.txt"));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.OpenFile("/toto.txt", FileMode.Create, FileAccess.ReadWrite));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Write));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.ReplaceFile("/a/a/a1.txt", "/A.txt", "/titi.txt", true));
 
-            Assert.Throws<IOException>(() => fs.SetAttributes("/toto.txt", FileAttributes.ReadOnly));
-            Assert.Throws<IOException>(() => fs.SetCreationTime("/toto.txt", DateTime.Now));
-            Assert.Throws<IOException>(() => fs.SetLastAccessTime("/toto.txt", DateTime.Now));
-            Assert.Throws<IOException>(() => fs.SetLastWriteTime("/toto.txt", DateTime.Now));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.SetAttributes("/toto.txt", FileAttributes.ReadOnly));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.SetCreationTime("/toto.txt", DateTime.Now));
+            await Assert.ThrowsAsync<IOException>(async() => await fs.SetLastAccessTime("/toto.txt", DateTime.Now));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.SetLastWriteTime("/toto.txt", DateTime.Now));
 
-            AssertCommonRead(fs, true);
+            await AssertCommonRead(fs, true);
         }
 
-        protected void AssertCommonRead(IFileSystem fs, bool isReadOnly = false)
+        protected async ValueTask AssertCommonRead(IFileSystem fs, bool isReadOnly = false)
         {
             {
                 var innerPath = fs.ConvertPathToInternal("/");
@@ -251,76 +255,128 @@ namespace Zio.Tests.FileSystems
                 Assert.Equal("/b", reverseInnerPath);
             }
 
-            Assert.True(fs.DirectoryExists("/"));
-            Assert.False(fs.FileExists(new UPath()));
+            Assert.True(await fs.DirectoryExists("/"));
+            Assert.False(await fs.FileExists(new UPath()));
 
-            Assert.Throws<ArgumentNullException>(() => fs.EnumeratePaths("/", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.EnumeratePaths("/", null));
             Assert.Throws<ArgumentNullException>(() => fs.ConvertPathFromInternal(null));
 
-            Assert.True(fs.FileExists("/A.txt"));
-            Assert.True(fs.FileExists("/b.txt"));
-            Assert.True(fs.FileExists("/b/b.i"));
-            Assert.True(fs.FileExists("/a/a/a1.txt"));
-            Assert.False(fs.FileExists("/yoyo.txt"));
+            Assert.True(await fs.FileExists("/A.txt"));
+            Assert.True(await fs.FileExists("/b.txt"));
+            Assert.True(await fs.FileExists("/b/b.i"));
+            Assert.True(await fs.FileExists("/a/a/a1.txt"));
+            Assert.False(await fs.FileExists("/yoyo.txt"));
 
-            Assert.True(fs.DirectoryExists("/a"));
-            Assert.True(fs.DirectoryExists("/a/b"));
-            Assert.True(fs.DirectoryExists("/a/C"));
-            Assert.True(fs.DirectoryExists("/b"));
-            Assert.True(fs.DirectoryExists("/C"));
-            Assert.True(fs.DirectoryExists("/d"));
-            Assert.False(fs.DirectoryExists("/yoyo"));
-            Assert.False(fs.DirectoryExists("/a/yoyo"));
+            Assert.True(await fs.DirectoryExists("/a"));
+            Assert.True(await fs.DirectoryExists("/a/b"));
+            Assert.True(await fs.DirectoryExists("/a/C"));
+            Assert.True(await fs.DirectoryExists("/b"));
+            Assert.True(await fs.DirectoryExists("/C"));
+            Assert.True(await fs.DirectoryExists("/d"));
+            Assert.False(await fs.DirectoryExists("/yoyo"));
+            Assert.False(await fs.DirectoryExists("/a/yoyo"));
 
-            Assert.StartsWith("content", fs.ReadAllText("/A.txt"));
-            Assert.StartsWith("content", fs.ReadAllText("/b.txt"));
-            Assert.StartsWith("content", fs.ReadAllText("/a/a/a1.txt"));
+            Assert.StartsWith("content", await fs.ReadAllText("/A.txt"));
+            Assert.StartsWith("content", await fs.ReadAllText("/b.txt"));
+            Assert.StartsWith("content", await fs.ReadAllText("/a/a/a1.txt"));
 
 
             var readOnlyFlag = isReadOnly ? FileAttributes.ReadOnly : 0;
 
-            Assert.Equal(readOnlyFlag | FileAttributes.Archive, fs.GetAttributes("/A.txt"));
-            Assert.Equal(readOnlyFlag | FileAttributes.Archive, fs.GetAttributes("/b.txt"));
-            Assert.Equal(readOnlyFlag | FileAttributes.Archive, fs.GetAttributes("/a/a/a1.txt"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Archive, await fs.GetAttributes("/A.txt"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Archive, await fs.GetAttributes("/b.txt"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Archive, await fs.GetAttributes("/a/a/a1.txt"));
 
-            Assert.True(fs.GetFileLength("/A.txt") > 0);
-            Assert.True(fs.GetFileLength("/b.txt") > 0);
-            Assert.True(fs.GetFileLength("/a/a/a1.txt") > 0);
+            Assert.True(await fs.GetFileLength("/A.txt") > 0);
+            Assert.True(await fs.GetFileLength("/b.txt") > 0);
+            Assert.True(await fs.GetFileLength("/a/a/a1.txt") > 0);
 
-            Assert.Equal(readOnlyFlag | FileAttributes.Directory, fs.GetAttributes("/a"));
-            Assert.Equal(readOnlyFlag | FileAttributes.Directory, fs.GetAttributes("/a/a"));
-            Assert.Equal(readOnlyFlag | FileAttributes.Directory, fs.GetAttributes("/C"));
-            Assert.Equal(readOnlyFlag | FileAttributes.Directory, fs.GetAttributes("/d"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Directory, await fs.GetAttributes("/a"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Directory, await fs.GetAttributes("/a/a"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Directory, await fs.GetAttributes("/C"));
+            Assert.Equal(readOnlyFlag | FileAttributes.Directory, await fs.GetAttributes("/d"));
 
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetCreationTime("/A.txt"));
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetLastAccessTime("/A.txt"));
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetLastWriteTime("/A.txt"));
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetCreationTime("/a/a/a1.txt"));
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetLastAccessTime("/a/a/a1.txt"));
-            Assert.NotEqual(FileSystem.DefaultFileTime, fs.GetLastWriteTime("/a/a/a1.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetCreationTime("/A.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetLastAccessTime("/A.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetLastWriteTime("/A.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetCreationTime("/a/a/a1.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetLastAccessTime("/a/a/a1.txt"));
+            Assert.NotEqual(FileSystem.DefaultFileTime, await fs.GetLastWriteTime("/a/a/a1.txt"));
 
-            new EnumeratePathsResult(fs).Check(_referenceEnumeratePathsResult);
+            (await EnumeratePathsResult.Create(fs)).Check(_referenceEnumeratePathsResult);
         }
 
-        protected void AssertFileSystemEqual(IFileSystem from, IFileSystem to)
+        protected async ValueTask AssertFileSystemEqual(IFileSystem from, IFileSystem to)
         {
-            new EnumeratePathsResult(from).Check(new EnumeratePathsResult(to));
+            (await EnumeratePathsResult.Create(from)).Check(await EnumeratePathsResult.Create(to));
         }
         
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         class EnumeratePathsResult
         {
-            private readonly List<UPath> TopDirs;
-            private readonly List<UPath> TopFiles;
-            private readonly List<UPath> TopEntries;
-            private readonly List<UPath> AllDirs;
-            private readonly List<UPath> AllFiles;
-            private readonly List<UPath> AllEntries;
-            private readonly List<UPath> AllFiles_txt;
-            private readonly List<UPath> AllDirs_a1;
-            private readonly List<UPath> AllDirs_a2;
-            private readonly List<UPath> AllFiles_i;
-            private readonly List<UPath> AllEntries_b;
+            private List<UPath> TopDirs;
+            private List<UPath> TopFiles;
+            private List<UPath> TopEntries;
+            private List<UPath> AllDirs;
+            private List<UPath> AllFiles;
+            private List<UPath> AllEntries;
+            private List<UPath> AllFiles_txt;
+            private List<UPath> AllDirs_a1;
+            private List<UPath> AllDirs_a2;
+            private List<UPath> AllFiles_i;
+            private List<UPath> AllEntries_b;
+
+            private EnumeratePathsResult()
+            {
+
+            }
+
+            public static async ValueTask<EnumeratePathsResult> Create(IFileSystem fs)
+            {
+                var result = new EnumeratePathsResult();
+
+                result.TopDirs = (await fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.Directory)).ToList();
+                // Check extension method
+                Assert.Equal(result.TopDirs, (await fs.EnumerateDirectories("/")).ToList());
+                Assert.Equal(result.TopDirs, (await fs.EnumerateDirectoryEntries("/")).Select(e => (UPath)e.FullName).ToList());
+                Assert.Equal(result.TopDirs.OrderBy(x => x.FullName).ToList(), (await fs.EnumerateItems("/", SearchOption.TopDirectoryOnly)).Where(e => e.IsDirectory).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList());
+
+                result.TopFiles = (await fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.File)).ToList();
+                // Check extension method
+                Assert.Equal(result.TopFiles, (await fs.EnumerateFiles("/")).ToList());
+                Assert.Equal(result.TopFiles, (await fs.EnumerateFileEntries("/")).Select(e => (UPath)e.FullName).ToList());
+                Assert.Equal(result.TopFiles.OrderBy(x => x.FullName).ToList(), (await fs.EnumerateItems("/", SearchOption.TopDirectoryOnly)).Where(e => !e.IsDirectory).OrderBy(e => e.Path.FullName.ToLowerInvariant()).Select(e => e.Path).ToList());
+
+                result.TopEntries = (await fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.Both)).ToList();
+                // Check extension method
+                Assert.Equal(result.TopEntries, (await fs.EnumeratePaths("/")).ToList());
+                Assert.Equal(result.TopEntries, (await fs.EnumerateFileSystemEntries("/")).Select(e => (UPath)e.FullName).ToList());
+                Assert.Equal(result.TopEntries.OrderBy(x => x.FullName).ToList(), (await fs.EnumerateItems("/", SearchOption.TopDirectoryOnly)).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList());
+
+                result.AllDirs = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Directory)).ToList();
+
+                result.AllFiles = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.File)).ToList();
+                // Check extension method
+                Assert.Equal(result.AllFiles, (await fs.EnumerateFiles("/", "*", SearchOption.AllDirectories)).ToList());
+                Assert.Equal(result.AllFiles, (await fs.EnumerateFileEntries("/", "*", SearchOption.AllDirectories)).Select(e => (UPath)e.FullName).ToList());
+                var expected = result.AllFiles.OrderBy(x => x.FullName).ToList();
+                var actual = (await fs.EnumerateItems("/", SearchOption.AllDirectories)).Where(e => !e.IsDirectory).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList();
+                Assert.Equal(expected, actual);
+
+                result.AllEntries = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both)).ToList();
+
+                result.AllFiles_txt = (await fs.EnumeratePaths("/", "*.txt", SearchOption.AllDirectories, SearchTarget.File)).ToList();
+                // Check extension method
+                Assert.Equal(result.AllFiles_txt, (await fs.EnumerateFiles("/", "*.txt", SearchOption.AllDirectories)).ToList());
+                Assert.Equal(result.AllFiles_txt, (await fs.EnumerateFileEntries("/", "*.txt", SearchOption.AllDirectories)).Select(e => (UPath)e.FullName).ToList());
+
+                result.AllDirs_a1 = (await fs.EnumeratePaths("/", "a/*", SearchOption.AllDirectories, SearchTarget.Directory)).ToList();
+                result.AllDirs_a2 = (await fs.EnumeratePaths("/a", "*", SearchOption.AllDirectories, SearchTarget.Directory)).ToList();
+                result.AllFiles_i = (await fs.EnumeratePaths("/", "*.i", SearchOption.AllDirectories, SearchTarget.File)).ToList();
+                result.AllEntries_b = (await fs.EnumeratePaths("/", "b*", SearchOption.AllDirectories, SearchTarget.Both)).ToList();
+
+                return result;
+            }
 
             public void Check(EnumeratePathsResult other)
             {
@@ -338,72 +394,29 @@ namespace Zio.Tests.FileSystems
                 AssertEx.Equivalent(AllDirs_a1, other.AllDirs_a1);
                 AssertEx.Equivalent(AllDirs_a2, other.AllDirs_a2);
             }
-
-            public EnumeratePathsResult(IFileSystem fs)
-            {
-                TopDirs = fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.Directory).ToList();
-                // Check extension method
-                Assert.Equal(TopDirs, fs.EnumerateDirectories("/").ToList());
-                Assert.Equal(TopDirs, fs.EnumerateDirectoryEntries("/").Select(e => (UPath)e.FullName).ToList());
-                Assert.Equal(TopDirs.OrderBy(x => x.FullName).ToList(), fs.EnumerateItems("/", SearchOption.TopDirectoryOnly).Where(e => e.IsDirectory).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList());
-
-                TopFiles = fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.File).ToList();
-                // Check extension method
-                Assert.Equal(TopFiles, fs.EnumerateFiles("/").ToList());
-                Assert.Equal(TopFiles, fs.EnumerateFileEntries("/").Select(e => (UPath)e.FullName).ToList());
-                Assert.Equal(TopFiles.OrderBy(x => x.FullName).ToList(), fs.EnumerateItems("/", SearchOption.TopDirectoryOnly).Where(e => !e.IsDirectory).OrderBy(e => e.Path.FullName.ToLowerInvariant()).Select(e => e.Path).ToList());
-
-                TopEntries = fs.EnumeratePaths("/", "*", SearchOption.TopDirectoryOnly, SearchTarget.Both).ToList();
-                // Check extension method
-                Assert.Equal(TopEntries, fs.EnumeratePaths("/").ToList());
-                Assert.Equal(TopEntries, fs.EnumerateFileSystemEntries("/").Select(e => (UPath)e.FullName).ToList());
-                Assert.Equal(TopEntries.OrderBy(x => x.FullName).ToList(), fs.EnumerateItems("/", SearchOption.TopDirectoryOnly).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList());
-
-                AllDirs = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Directory).ToList();
-
-                AllFiles = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.File).ToList();
-                // Check extension method
-                Assert.Equal(AllFiles, fs.EnumerateFiles("/", "*", SearchOption.AllDirectories).ToList());
-                Assert.Equal(AllFiles, fs.EnumerateFileEntries("/", "*", SearchOption.AllDirectories).Select(e => (UPath)e.FullName).ToList());
-                var expected = AllFiles.OrderBy(x => x.FullName).ToList();
-                var actual = fs.EnumerateItems("/", SearchOption.AllDirectories).Where(e => !e.IsDirectory).OrderBy(e => e.Path.FullName).Select(e => e.Path).ToList();
-                Assert.Equal(expected, actual);
-
-                AllEntries = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList();
-
-                AllFiles_txt = fs.EnumeratePaths("/", "*.txt", SearchOption.AllDirectories, SearchTarget.File).ToList();
-                // Check extension method
-                Assert.Equal(AllFiles_txt, fs.EnumerateFiles("/", "*.txt", SearchOption.AllDirectories).ToList());
-                Assert.Equal(AllFiles_txt, fs.EnumerateFileEntries("/", "*.txt", SearchOption.AllDirectories).Select(e => (UPath)e.FullName).ToList());
-
-                AllDirs_a1 = fs.EnumeratePaths("/", "a/*", SearchOption.AllDirectories, SearchTarget.Directory).ToList();
-                AllDirs_a2 = fs.EnumeratePaths("/a", "*", SearchOption.AllDirectories, SearchTarget.Directory).ToList();
-                AllFiles_i = fs.EnumeratePaths("/", "*.i", SearchOption.AllDirectories, SearchTarget.File).ToList();
-                AllEntries_b = fs.EnumeratePaths("/", "b*", SearchOption.AllDirectories, SearchTarget.Both).ToList();
-            }
         }
 
-        private void CreateFolderStructure(IFileSystem fs)
+        private async ValueTask CreateFolderStructure(IFileSystem fs)
         {
-            void CreateFolderStructure(UPath root)
+            async ValueTask CreateFolderStructure(UPath root)
             {
 
                 foreach (var dir in Directories)
                 {
                     var pathDir = root / dir;
-                    fs.CreateDirectory(pathDir);
+                    await fs.CreateDirectory(pathDir);
                 }
 
                 for (var i = 0; i < Files.Length; i++)
                 {
                     var file = Files[i];
                     var pathFile = root / file;
-                    fs.WriteAllText(pathFile, "content" + i);
+                    await fs.WriteAllText(pathFile, "content" + i);
                 }
             }
 
-            CreateFolderStructure(UPath.Root);
-            CreateFolderStructure(UPath.Root / "a");
+            await CreateFolderStructure(UPath.Root);
+            await CreateFolderStructure(UPath.Root / "a");
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestFileSystemCompactBase.cs
+++ b/src/Zio.Tests/FileSystems/TestFileSystemCompactBase.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Zio;
 using Zio.FileSystems;
@@ -23,83 +24,83 @@ namespace Zio.Tests.FileSystems
         }
 
         [Fact]
-        public void TestDirectory()
+        public async ValueTask TestDirectory()
         {
-            Assert.True(fs.DirectoryExists("/"));
-            Assert.False(fs.DirectoryExists(null));
+            Assert.True(await fs.DirectoryExists("/"));
+            Assert.False(await fs.DirectoryExists(null));
 
             // Test CreateDirectory
-            fs.CreateDirectory("/test");
-            Assert.True(fs.DirectoryExists("/test"));
-            Assert.False(fs.DirectoryExists("/test2"));
+            await fs.CreateDirectory("/test");
+            Assert.True(await fs.DirectoryExists("/test"));
+            Assert.False(await fs.DirectoryExists("/test2"));
 
             // Test CreateDirectory (sub folders)
-            fs.CreateDirectory("/test/test1/test2/test3");
-            Assert.True(fs.DirectoryExists("/test/test1/test2/test3"));
-            Assert.True(fs.DirectoryExists("/test/test1/test2"));
-            Assert.True(fs.DirectoryExists("/test/test1"));
-            Assert.True(fs.DirectoryExists("/test"));
+            await fs.CreateDirectory("/test/test1/test2/test3");
+            Assert.True(await fs.DirectoryExists("/test/test1/test2/test3"));
+            Assert.True(await fs.DirectoryExists("/test/test1/test2"));
+            Assert.True(await fs.DirectoryExists("/test/test1"));
+            Assert.True(await fs.DirectoryExists("/test"));
 
             // Test DeleteDirectory
-            fs.DeleteDirectory("/test/test1/test2/test3", false);
-            Assert.False(fs.DirectoryExists("/test/test1/test2/test3"));
-            Assert.True(fs.DirectoryExists("/test/test1/test2"));
-            Assert.True(fs.DirectoryExists("/test/test1"));
-            Assert.True(fs.DirectoryExists("/test"));
+            await fs.DeleteDirectory("/test/test1/test2/test3", false);
+            Assert.False(await fs.DirectoryExists("/test/test1/test2/test3"));
+            Assert.True(await fs.DirectoryExists("/test/test1/test2"));
+            Assert.True(await fs.DirectoryExists("/test/test1"));
+            Assert.True(await fs.DirectoryExists("/test"));
 
             // Test MoveDirectory
-            fs.MoveDirectory("/test", "/test2");
-            Assert.True(fs.DirectoryExists("/test2/test1/test2"));
-            Assert.True(fs.DirectoryExists("/test2/test1"));
-            Assert.True(fs.DirectoryExists("/test2"));
+            await fs.MoveDirectory("/test", "/test2");
+            Assert.True(await fs.DirectoryExists("/test2/test1/test2"));
+            Assert.True(await fs.DirectoryExists("/test2/test1"));
+            Assert.True(await fs.DirectoryExists("/test2"));
 
             // Test MoveDirectory to sub directory
-            fs.CreateDirectory("/testsub");
-            Assert.True(fs.DirectoryExists("/testsub"));
-            fs.MoveDirectory("/test2", "/testsub/testx");
-            Assert.False(fs.DirectoryExists("/test2"));
-            Assert.True(fs.DirectoryExists("/testsub/testx/test1/test2"));
-            Assert.True(fs.DirectoryExists("/testsub/testx/test1"));
-            Assert.True(fs.DirectoryExists("/testsub/testx"));
+            await fs.CreateDirectory("/testsub");
+            Assert.True(await fs.DirectoryExists("/testsub"));
+            await fs.MoveDirectory("/test2", "/testsub/testx");
+            Assert.False(await fs.DirectoryExists("/test2"));
+            Assert.True(await fs.DirectoryExists("/testsub/testx/test1/test2"));
+            Assert.True(await fs.DirectoryExists("/testsub/testx/test1"));
+            Assert.True(await fs.DirectoryExists("/testsub/testx"));
 
             // Test DeleteDirectory - recursive
-            fs.DeleteDirectory("/testsub", true);
-            Assert.False(fs.DirectoryExists("/testsub/testx/test1/test2"));
-            Assert.False(fs.DirectoryExists("/testsub/testx/test1"));
-            Assert.False(fs.DirectoryExists("/testsub/testx"));
-            Assert.False(fs.DirectoryExists("/testsub"));
+            await fs.DeleteDirectory("/testsub", true);
+            Assert.False(await fs.DirectoryExists("/testsub/testx/test1/test2"));
+            Assert.False(await fs.DirectoryExists("/testsub/testx/test1"));
+            Assert.False(await fs.DirectoryExists("/testsub/testx"));
+            Assert.False(await fs.DirectoryExists("/testsub"));
         }
 
         [Fact]
-        public void TestDirectoryExceptions()
+        public async ValueTask TestDirectoryExceptions()
         {
-            Assert.Throws<DirectoryNotFoundException>(() => fs.DeleteDirectory("/dir", true));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.DeleteDirectory("/dir", true));
 
-            Assert.Throws<DirectoryNotFoundException>(() => fs.MoveDirectory("/dir1", "/dir2"));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.MoveDirectory("/dir1", "/dir2"));
 
-            Assert.Throws<UnauthorizedAccessException>(() => fs.CreateDirectory("/"));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.CreateDirectory("/"));
 
-            fs.CreateDirectory("/dir1");
-            Assert.Throws<UnauthorizedAccessException>(() => fs.DeleteFile("/dir1"));
-            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir1", "/dir1"));
+            await fs.CreateDirectory("/dir1");
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.DeleteFile("/dir1"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveDirectory("/dir1", "/dir1"));
 
-            fs.WriteAllText("/toto.txt", "test");
-            Assert.Throws<IOException>(() => fs.CreateDirectory("/toto.txt"));
-            Assert.Throws<IOException>(() => fs.DeleteDirectory("/toto.txt", true));
-            Assert.Throws<IOException>(() => fs.MoveDirectory("/toto.txt", "/test"));
+            await fs.WriteAllText("/toto.txt", "test");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CreateDirectory("/toto.txt"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.DeleteDirectory("/toto.txt", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveDirectory("/toto.txt", "/test"));
 
-            fs.CreateDirectory("/dir2");
-            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir1", "/dir2"));
+            await fs.CreateDirectory("/dir2");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveDirectory("/dir1", "/dir2"));
 
-            fs.SetAttributes("/dir1", FileAttributes.Directory | FileAttributes.ReadOnly);
-            Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir1", true));
+            await fs.SetAttributes("/dir1", FileAttributes.Directory | FileAttributes.ReadOnly);
+            await Assert.ThrowsAsync<IOException>(async () => await fs.DeleteDirectory("/dir1", true));
         }
 
         [Fact]
-        public void TestFile()
+        public async ValueTask TestFile()
         {
             // Test CreateFile/OpenFile
-            var stream = fs.CreateFile("/toto.txt");
+            var stream = await fs.CreateFile("/toto.txt");
             var writer = new StreamWriter(stream);
             var originalContent = "This is the content";
             writer.Write(originalContent);
@@ -107,259 +108,259 @@ namespace Zio.Tests.FileSystems
             stream.Dispose();
 
             // Test FileExists
-            Assert.False(fs.FileExists(null));
-            Assert.False(fs.FileExists("/titi.txt"));
-            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.False(await fs.FileExists(null));
+            Assert.False(await fs.FileExists("/titi.txt"));
+            Assert.True(await fs.FileExists("/toto.txt"));
 
             // ReadAllText
-            var content = fs.ReadAllText("/toto.txt");
+            var content = await fs.ReadAllText("/toto.txt");
             Assert.Equal(originalContent, content);
 
             // sleep for creation time comparison
             Thread.Sleep(16);
 
             // Test CopyFile
-            fs.CopyFile("/toto.txt", "/titi.txt", true);
-            Assert.True(fs.FileExists("/toto.txt"));
-            Assert.True(fs.FileExists("/titi.txt"));
-            content = fs.ReadAllText("/titi.txt");
+            await fs.CopyFile("/toto.txt", "/titi.txt", true);
+            Assert.True(await fs.FileExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/titi.txt"));
+            content = await fs.ReadAllText("/titi.txt");
             Assert.Equal(originalContent, content);
             
             // Test Attributes/Times
-            Assert.True(fs.GetFileLength("/toto.txt") > 0);
-            Assert.Equal(fs.GetFileLength("/toto.txt"), fs.GetFileLength("/titi.txt"));
-            Assert.Equal(fs.GetAttributes("/toto.txt"), fs.GetAttributes("/titi.txt"));
-            Assert.NotEqual(fs.GetCreationTime("/toto.txt"), fs.GetCreationTime("/titi.txt"));
+            Assert.True(await fs.GetFileLength("/toto.txt") > 0);
+            Assert.Equal(await fs.GetFileLength("/toto.txt"), await fs.GetFileLength("/titi.txt"));
+            Assert.Equal(await fs.GetAttributes("/toto.txt"), await fs.GetAttributes("/titi.txt"));
+            Assert.NotEqual(await fs.GetCreationTime("/toto.txt"), await fs.GetCreationTime("/titi.txt"));
             // Because we read titi.txt just before, access time must be different
             // Following test is disabled as it seems unstable with NTFS?
             // Assert.NotEqual(fs.GetLastAccessTime("/toto.txt"), fs.GetLastAccessTime("/titi.txt"));
-            Assert.Equal(fs.GetLastWriteTime("/toto.txt"), fs.GetLastWriteTime("/titi.txt"));
+            Assert.Equal(await fs.GetLastWriteTime("/toto.txt"), await fs.GetLastWriteTime("/titi.txt"));
 
             var now = DateTime.Now + TimeSpan.FromSeconds(10);
             var now1 = DateTime.Now + TimeSpan.FromSeconds(11);
             var now2 = DateTime.Now + TimeSpan.FromSeconds(12);
-            fs.SetCreationTime("/toto.txt", now);
-            fs.SetLastAccessTime("/toto.txt", now1);
-            fs.SetLastWriteTime("/toto.txt", now2);
-            Assert.Equal(now, fs.GetCreationTime("/toto.txt"));
-            Assert.Equal(now1, fs.GetLastAccessTime("/toto.txt"));
-            Assert.Equal(now2, fs.GetLastWriteTime("/toto.txt"));
+            await fs.SetCreationTime("/toto.txt", now);
+            await fs.SetLastAccessTime("/toto.txt", now1);
+            await fs.SetLastWriteTime("/toto.txt", now2);
+            Assert.Equal(now, await fs.GetCreationTime("/toto.txt"));
+            Assert.Equal(now1, await fs.GetLastAccessTime("/toto.txt"));
+            Assert.Equal(now2, await fs.GetLastWriteTime("/toto.txt"));
 
-            Assert.NotEqual(fs.GetCreationTime("/toto.txt"), fs.GetCreationTime("/titi.txt"));
-            Assert.NotEqual(fs.GetLastAccessTime("/toto.txt"), fs.GetLastAccessTime("/titi.txt"));
-            Assert.NotEqual(fs.GetLastWriteTime("/toto.txt"), fs.GetLastWriteTime("/titi.txt"));
+            Assert.NotEqual(await fs.GetCreationTime("/toto.txt"), await fs.GetCreationTime("/titi.txt"));
+            Assert.NotEqual(await fs.GetLastAccessTime("/toto.txt"), await fs.GetLastAccessTime("/titi.txt"));
+            Assert.NotEqual(await fs.GetLastWriteTime("/toto.txt"), await fs.GetLastWriteTime("/titi.txt"));
 
             // Test MoveFile
-            fs.MoveFile("/toto.txt", "/tata.txt");
-            Assert.False(fs.FileExists("/toto.txt"));
-            Assert.True(fs.FileExists("/tata.txt"));
-            Assert.True(fs.FileExists("/titi.txt"));
-            content = fs.ReadAllText("/tata.txt");
+            await fs.MoveFile("/toto.txt", "/tata.txt");
+            Assert.False(await fs.FileExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/tata.txt"));
+            Assert.True(await fs.FileExists("/titi.txt"));
+            content = await fs.ReadAllText("/tata.txt");
             Assert.Equal(originalContent, content);
 
             // Test Enumerate file
-            var files = fs.EnumerateFiles("/").Select(p => p.FullName).ToList();
+            var files = (await fs.EnumerateFiles("/")).Select(p => p.FullName).ToList();
             files.Sort();
             Assert.Equal(new List<string>() {"/tata.txt", "/titi.txt"}, files);
 
-            var dirs = fs.EnumerateDirectories("/").Select(p => p.FullName).ToList();
+            var dirs = (await fs.EnumerateDirectories("/")).Select(p => p.FullName).ToList();
             Assert.Empty(dirs);
 
             // Check ReplaceFile
             var originalContent2 = "this is a content2";
-            fs.WriteAllText("/tata.txt", originalContent2);
-            fs.ReplaceFile("/tata.txt", "/titi.txt", "/titi.bak.txt", true);
-            Assert.False(fs.FileExists("/tata.txt"));
-            Assert.True(fs.FileExists("/titi.txt"));
-            Assert.True(fs.FileExists("/titi.bak.txt"));
-            content = fs.ReadAllText("/titi.txt");
+            await fs.WriteAllText("/tata.txt", originalContent2);
+            await fs.ReplaceFile("/tata.txt", "/titi.txt", "/titi.bak.txt", true);
+            Assert.False(await fs.FileExists("/tata.txt"));
+            Assert.True(await fs.FileExists("/titi.txt"));
+            Assert.True(await fs.FileExists("/titi.bak.txt"));
+            content = await fs.ReadAllText("/titi.txt");
             Assert.Equal(originalContent2, content);
-            content = fs.ReadAllText("/titi.bak.txt");
+            content = await fs.ReadAllText("/titi.bak.txt");
             Assert.Equal(originalContent, content);
 
             // Check File ReadOnly
-            fs.SetAttributes("/titi.txt", FileAttributes.ReadOnly);
-            Assert.Throws<UnauthorizedAccessException>(() => fs.DeleteFile("/titi.txt"));
-            Assert.Throws<UnauthorizedAccessException>(() => fs.CopyFile("/titi.bak.txt", "/titi.txt", true));
-            Assert.Throws<UnauthorizedAccessException>(() => fs.OpenFile("/titi.txt", FileMode.Open, FileAccess.ReadWrite));
-            fs.SetAttributes("/titi.txt", FileAttributes.Normal);
+            await fs.SetAttributes("/titi.txt", FileAttributes.ReadOnly);
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.DeleteFile("/titi.txt"));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.CopyFile("/titi.bak.txt", "/titi.txt", true));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.OpenFile("/titi.txt", FileMode.Open, FileAccess.ReadWrite));
+            await fs.SetAttributes("/titi.txt", FileAttributes.Normal);
 
             // Delete File
-            fs.DeleteFile("/titi.txt");
-            Assert.False(fs.FileExists("/titi.txt"));
-            fs.DeleteFile("/titi.bak.txt");
-            Assert.False(fs.FileExists("/titi.bak.txt"));
+            await fs.DeleteFile("/titi.txt");
+            Assert.False(await fs.FileExists("/titi.txt"));
+            await fs.DeleteFile("/titi.bak.txt");
+            Assert.False(await fs.FileExists("/titi.bak.txt"));
         }
 
         [Fact]
-        public void TestMoveFileDifferentDirectory()
+        public async ValueTask TestMoveFileDifferentDirectory()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            fs.CreateDirectory("/dir");
+            await fs.CreateDirectory("/dir");
 
-            fs.MoveFile("/toto.txt", "/dir/titi.txt");
+            await fs.MoveFile("/toto.txt", "/dir/titi.txt");
 
-            Assert.False(fs.FileExists("/toto.txt"));
-            Assert.True(fs.FileExists("/dir/titi.txt"));
+            Assert.False(await fs.FileExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/dir/titi.txt"));
 
-            Assert.Equal("content", fs.ReadAllText("/dir/titi.txt"));
+            Assert.Equal("content", await fs.ReadAllText("/dir/titi.txt"));
         }
 
         [Fact]
-        public void TestReplaceFileDifferentDirectory()
+        public async ValueTask TestReplaceFileDifferentDirectory()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            fs.CreateDirectory("/dir");
-            fs.WriteAllText("/dir/tata.txt", "content2");
+            await fs.CreateDirectory("/dir");
+            await fs.WriteAllText("/dir/tata.txt", "content2");
 
-            fs.CreateDirectory("/dir2");
+            await fs.CreateDirectory("/dir2");
 
-            fs.ReplaceFile("/toto.txt", "/dir/tata.txt", "/dir2/titi.txt", true);
-            Assert.True(fs.FileExists("/dir/tata.txt"));
-            Assert.True(fs.FileExists("/dir2/titi.txt"));
+            await fs.ReplaceFile("/toto.txt", "/dir/tata.txt", "/dir2/titi.txt", true);
+            Assert.True(await fs.FileExists("/dir/tata.txt"));
+            Assert.True(await fs.FileExists("/dir2/titi.txt"));
 
-            Assert.Equal("content", fs.ReadAllText("/dir/tata.txt"));
-            Assert.Equal("content2", fs.ReadAllText("/dir2/titi.txt"));
+            Assert.Equal("content", await fs.ReadAllText("/dir/tata.txt"));
+            Assert.Equal("content2", await fs.ReadAllText("/dir2/titi.txt"));
 
-            fs.ReplaceFile("/dir/tata.txt", "/dir2/titi.txt", "/titi.txt", true);
-            Assert.False(fs.FileExists("/dir/tata.txt"));
-            Assert.True(fs.FileExists("/dir2/titi.txt"));
-            Assert.True(fs.FileExists("/titi.txt"));
+            await fs.ReplaceFile("/dir/tata.txt", "/dir2/titi.txt", "/titi.txt", true);
+            Assert.False(await fs.FileExists("/dir/tata.txt"));
+            Assert.True(await fs.FileExists("/dir2/titi.txt"));
+            Assert.True(await fs.FileExists("/titi.txt"));
         }
 
         [Fact]
-        public void TestOpenFileAppend()
+        public async ValueTask TestOpenFileAppend()
         {
-            fs.AppendAllText("/toto.txt", "content");
-            Assert.True(fs.FileExists("/toto.txt"));
-            Assert.Equal("content", fs.ReadAllText("/toto.txt"));
+            await fs.AppendAllText("/toto.txt", "content");
+            Assert.True(await fs.FileExists("/toto.txt"));
+            Assert.Equal("content", await fs.ReadAllText("/toto.txt"));
 
-            fs.AppendAllText("/toto.txt", "content");
-            Assert.True(fs.FileExists("/toto.txt"));
-            Assert.Equal("contentcontent", fs.ReadAllText("/toto.txt"));
+            await fs.AppendAllText("/toto.txt", "content");
+            Assert.True(await fs.FileExists("/toto.txt"));
+            Assert.Equal("contentcontent", await fs.ReadAllText("/toto.txt"));
         }
 
         [Fact]
-        public void TestOpenFileTruncate()
+        public async ValueTask TestOpenFileTruncate()
         {
-            fs.WriteAllText("/toto.txt", "content");
-            Assert.True(fs.FileExists("/toto.txt"));
-            Assert.Equal("content", fs.ReadAllText("/toto.txt"));
+            await fs.WriteAllText("/toto.txt", "content");
+            Assert.True(await fs.FileExists("/toto.txt"));
+            Assert.Equal("content", await fs.ReadAllText("/toto.txt"));
 
-            var stream = fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write);
+            var stream = await fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write);
             stream.Dispose();
-            Assert.Equal<long>(0, fs.GetFileLength("/toto.txt"));
-            Assert.Equal("", fs.ReadAllText("/toto.txt"));
+            Assert.Equal<long>(0, await fs.GetFileLength("/toto.txt"));
+            Assert.Equal("", await fs.ReadAllText("/toto.txt"));
         }
 
         [Fact]
-        public void TestFileExceptions()
+        public async ValueTask TestFileExceptions()
         {
-            fs.CreateDirectory("/dir1");
+            await fs.CreateDirectory("/dir1");
 
-            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/toto.txt"));
-            Assert.Throws<FileNotFoundException>(() => fs.CopyFile("/toto.txt", "/toto.bak.txt", true));
-            Assert.Throws<UnauthorizedAccessException>(() => fs.CopyFile("/dir1", "/toto.bak.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.MoveFile("/toto.txt", "/titi.txt"));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.GetFileLength("/toto.txt"));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.CopyFile("/toto.txt", "/toto.bak.txt", true));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.CopyFile("/dir1", "/toto.bak.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.MoveFile("/toto.txt", "/titi.txt"));
             // If the file to be deleted does not exist, no exception is thrown.
-            fs.DeleteFile("/toto.txt");
-            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read));
-            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write));
+            await fs.DeleteFile("/toto.txt");
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write));
 
-            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/dir1/toto.txt"));
-            Assert.Throws<FileNotFoundException>(() => fs.CopyFile("/dir1/toto.txt", "/toto.bak.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.MoveFile("/dir1/toto.txt", "/titi.txt"));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.GetFileLength("/dir1/toto.txt"));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.CopyFile("/dir1/toto.txt", "/toto.bak.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.MoveFile("/dir1/toto.txt", "/titi.txt"));
             // If the file to be deleted does not exist, no exception is thrown.
-            fs.DeleteFile("/dir1/toto.txt");
-            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/dir1/toto.txt", FileMode.Open, FileAccess.Read));
+            await fs.DeleteFile("/dir1/toto.txt");
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.OpenFile("/dir1/toto.txt", FileMode.Open, FileAccess.Read));
 
-            fs.WriteAllText("/toto.txt", "yo");
-            fs.CopyFile("/toto.txt", "/titi.txt", false);
-            fs.CopyFile("/toto.txt", "/titi.txt", true);
+            await fs.WriteAllText("/toto.txt", "yo");
+            await fs.CopyFile("/toto.txt", "/titi.txt", false);
+            await fs.CopyFile("/toto.txt", "/titi.txt", true);
 
-            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/dir1"));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.GetFileLength("/dir1"));
 
             var defaultTime = new DateTime(1601, 01, 01, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
-            Assert.Equal(defaultTime,fs.GetCreationTime("/dest"));
-            Assert.Equal(defaultTime, fs.GetLastWriteTime("/dest"));
-            Assert.Equal(defaultTime, fs.GetLastAccessTime("/dest"));
+            Assert.Equal(defaultTime, await fs.GetCreationTime("/dest"));
+            Assert.Equal(defaultTime, await fs.GetLastWriteTime("/dest"));
+            Assert.Equal(defaultTime, await fs.GetLastAccessTime("/dest"));
 
-            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var stream1 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                Assert.Throws<IOException>(() =>
+                await Assert.ThrowsAsync<IOException>(async () =>
                 {
-                    using (var stream2 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+                    using (var stream2 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
                     {
                     }
                 });
             }
 
-            Assert.Throws<UnauthorizedAccessException>(() => fs.OpenFile("/dir1", FileMode.Open, FileAccess.Read));
-            Assert.Throws<DirectoryNotFoundException>(() => fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read));
-            Assert.Throws<DirectoryNotFoundException>(() => fs.CopyFile("/toto.txt", "/dest/toto.txt", true));
-            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/titi.txt", false));
-            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/dir1", true));
-            Assert.Throws<DirectoryNotFoundException>(() => fs.MoveFile("/toto.txt", "/dest/toto.txt"));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.OpenFile("/dir1", FileMode.Open, FileAccess.Read));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.CopyFile("/toto.txt", "/dest/toto.txt", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/toto.txt", "/titi.txt", false));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/toto.txt", "/dir1", true));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.MoveFile("/toto.txt", "/dest/toto.txt"));
 
-            fs.WriteAllText("/titi.txt", "yo2");
-            Assert.Throws<IOException>(() => fs.MoveFile("/toto.txt", "/titi.txt"));
+            await fs.WriteAllText("/titi.txt", "yo2");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveFile("/toto.txt", "/titi.txt"));
 
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/1.txt", default(UPath), true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/1.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/2.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/3.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/dir/2.txt", "/3.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/2.txt", "/3.txt", true));
-            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/2.txt", "/toto.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/1.txt", "/1.txt", default(UPath), true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/1.txt", "/2.txt", "/1.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/1.txt", "/2.txt", "/2.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/1.txt", "/2.txt", "/3.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/toto.txt", "/dir/2.txt", "/3.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async() => await fs.ReplaceFile("/toto.txt", "/2.txt", "/3.txt", true));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.ReplaceFile("/toto.txt", "/2.txt", "/toto.txt", true));
 
             // Not same behavior in Physical vs Memory
             if (fs is MemoryFileSystem)
             {
-                Assert.Throws<DirectoryNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/titi.txt", "/dir/3.txt", true));
+                await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.ReplaceFile("/toto.txt", "/titi.txt", "/dir/3.txt", true));
 
-                fs.WriteAllText("/tata.txt", "yo3");
-                Assert.True(fs.FileExists("/tata.txt"));
-                fs.ReplaceFile("/toto.txt", "/titi.txt", "/tata.txt", true);
+                await fs.WriteAllText("/tata.txt", "yo3");
+                Assert.True(await fs.FileExists("/tata.txt"));
+                await fs.ReplaceFile("/toto.txt", "/titi.txt", "/tata.txt", true);
                 // TODO: check that tata.txt was correctly removed
             }
         }
 
         [Fact]
-        public void TestDirectoryDeleteAndOpenFile()
+        public async ValueTask TestDirectoryDeleteAndOpenFile()
         {
-            fs.CreateDirectory("/dir");
-            fs.WriteAllText("/dir/toto.txt", "content");
-            var stream = fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read);
+            await fs.CreateDirectory("/dir");
+            await fs.WriteAllText("/dir/toto.txt", "content");
+            var stream = await fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read);
 
-            Assert.Throws<IOException>(() => fs.DeleteFile("/dir/toto.txt"));
-            Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.DeleteFile("/dir/toto.txt"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.DeleteDirectory("/dir", true));
 
             stream.Dispose();
-            fs.SetAttributes("/dir/toto.txt", FileAttributes.ReadOnly);
-            Assert.Throws<UnauthorizedAccessException>(() => fs.DeleteDirectory("/dir", true));
-            fs.SetAttributes("/dir/toto.txt", FileAttributes.Normal);
-            fs.DeleteDirectory("/dir", true);
+            await fs.SetAttributes("/dir/toto.txt", FileAttributes.ReadOnly);
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await fs.DeleteDirectory("/dir", true));
+            await fs.SetAttributes("/dir/toto.txt", FileAttributes.Normal);
+            await fs.DeleteDirectory("/dir", true);
 
-            var entries = fs.EnumeratePaths("/").ToList();
+            var entries = (await fs.EnumeratePaths("/")).ToList();
             Assert.Empty(entries);
         }
 
         [Fact]
-        public void TestOpenFileMultipleRead()
+        public async ValueTask TestOpenFileMultipleRead()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/toto.txt"));
 
-            using (var tmp = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
+            using (var tmp = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
             {
-                 Assert.Throws<IOException>(() => fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read));
+                 await Assert.ThrowsAsync<IOException>(async () => await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read));
             }
 
-            var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
-            var stream2 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream1 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream2 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
 
             stream1.ReadByte();
             Assert.Equal<long>(1, stream1.Position);
@@ -372,36 +373,36 @@ namespace Zio.Tests.FileSystems
             stream2.Dispose();
 
             // We try to write back on the same file after closing
-            fs.WriteAllText("/toto.txt", "content2");
+            await fs.WriteAllText("/toto.txt", "content2");
         }
 
         [Fact]
-        public void TestOpenFileReadAndWriteFail()
+        public async ValueTask TestOpenFileReadAndWriteFail()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/toto.txt"));
 
-            var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read);
+            var stream1 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read);
 
             stream1.ReadByte();
             Assert.Equal<long>(1, stream1.Position);
 
             // We try to write back on the same file before closing
-            Assert.Throws<IOException>(() => fs.WriteAllText("/toto.txt", "content2"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.WriteAllText("/toto.txt", "content2"));
 
             // Make sure that checking for a file exists or directory exists doesn't throw an exception "being used"
-            Assert.True(fs.FileExists("/toto.txt"));
-            Assert.False(fs.DirectoryExists("/toto.txt"));
+            Assert.True(await fs.FileExists("/toto.txt"));
+            Assert.False(await fs.DirectoryExists("/toto.txt"));
 
             stream1.Dispose();
         }
 
         [Fact]
-        public void TestOpenFileReadAndWriteShared()
+        public async ValueTask TestOpenFileReadAndWriteShared()
         {
-            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
-            using (var stream2 = fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var stream1 = await fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var stream2 = await fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
                 var buffer = Encoding.UTF8.GetBytes("abc");
                 stream1.Write(buffer, 0, buffer.Length);
@@ -413,55 +414,55 @@ namespace Zio.Tests.FileSystems
                 stream2.Flush();
             }
 
-            var content = fs.ReadAllText("/toto.txt");
+            var content = await fs.ReadAllText("/toto.txt");
             Assert.Equal("adc", content);
         }
 
         [Fact]
-        public void TestOpenFileReadAndWriteShared2()
+        public async ValueTask TestOpenFileReadAndWriteShared2()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
             // No exceptions
-            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var stream1 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
-                using (var stream2 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var stream2 = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                 }
             }
-            var content = fs.ReadAllText("/toto.txt");
+            var content = await fs.ReadAllText("/toto.txt");
             Assert.Equal("content", content);
         }
 
         [Fact]
-        public void TestCopyFileToSameFile()
+        public async ValueTask TestCopyFileToSameFile()
         {
-            fs.WriteAllText("/toto.txt", "content");
-            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/toto.txt", true));
-            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/toto.txt", false));
+            await fs.WriteAllText("/toto.txt", "content");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/toto.txt", "/toto.txt", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/toto.txt", "/toto.txt", false));
 
-            fs.CreateDirectory("/dir");
+            await fs.CreateDirectory("/dir");
 
-            fs.WriteAllText("/dir/toto.txt", "content");
-            Assert.Throws<IOException>(() => fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", true));
-            Assert.Throws<IOException>(() => fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", false));
+            await fs.WriteAllText("/dir/toto.txt", "content");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", false));
         }
 
         [Fact]
-        public void TestEnumeratePaths()
+        public async ValueTask TestEnumeratePaths()
         {
-            fs.CreateDirectory("/dir1/a/b");
-            fs.CreateDirectory("/dir1/a1");
-            fs.CreateDirectory("/dir2/c");
-            fs.CreateDirectory("/dir3");
+            await fs.CreateDirectory("/dir1/a/b");
+            await fs.CreateDirectory("/dir1/a1");
+            await fs.CreateDirectory("/dir2/c");
+            await fs.CreateDirectory("/dir3");
 
-            fs.WriteAllText("/dir1/a/file10.txt", "content10");
-            fs.WriteAllText("/dir1/a1/file11.txt", "content11");
-            fs.WriteAllText("/dir2/file20.txt", "content20");
+            await fs.WriteAllText("/dir1/a/file10.txt", "content10");
+            await fs.WriteAllText("/dir1/a1/file11.txt", "content11");
+            await fs.WriteAllText("/dir2/file20.txt", "content20");
 
-            fs.WriteAllText("/file01.txt", "content1");
-            fs.WriteAllText("/file02.txt", "content2");
+            await fs.WriteAllText("/file01.txt", "content1");
+            await fs.WriteAllText("/file02.txt", "content2");
 
-            var entries = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList<UPath>();
+            var entries = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both)).ToList<UPath>();
             entries.Sort();
 
             Assert.Equal(new List<UPath>()
@@ -482,7 +483,7 @@ namespace Zio.Tests.FileSystems
                 , entries);
 
 
-            var folders = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Directory).ToList<UPath>();
+            var folders = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Directory)).ToList<UPath>();
             folders.Sort();
 
             Assert.Equal(new List<UPath>()
@@ -498,7 +499,7 @@ namespace Zio.Tests.FileSystems
                 , folders);
 
 
-            var files = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            var files = (await fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.File)).ToList<UPath>();
             files.Sort();
 
             Assert.Equal(new List<UPath>()
@@ -512,7 +513,7 @@ namespace Zio.Tests.FileSystems
                 , files);
 
 
-            folders = fs.EnumeratePaths("/dir1", "a", SearchOption.AllDirectories, SearchTarget.Directory).ToList<UPath>();
+            folders = (await fs.EnumeratePaths("/dir1", "a", SearchOption.AllDirectories, SearchTarget.Directory)).ToList<UPath>();
             folders.Sort();
             Assert.Equal(new List<UPath>()
                 {
@@ -521,7 +522,7 @@ namespace Zio.Tests.FileSystems
                 , folders);
 
 
-            files = fs.EnumeratePaths("/dir1", "file1?.txt", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            files = (await fs.EnumeratePaths("/dir1", "file1?.txt", SearchOption.AllDirectories, SearchTarget.File)).ToList<UPath>();
             files.Sort();
 
             Assert.Equal(new List<UPath>()
@@ -531,7 +532,7 @@ namespace Zio.Tests.FileSystems
                 }
                 , files);
 
-            files = fs.EnumeratePaths("/", "file?0.txt", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            files = (await fs.EnumeratePaths("/", "file?0.txt", SearchOption.AllDirectories, SearchTarget.File)).ToList<UPath>();
             files.Sort();
 
             Assert.Equal(new List<UPath>()
@@ -543,45 +544,45 @@ namespace Zio.Tests.FileSystems
         }
 
         [Fact]
-        public void TestMultithreaded()
+        public async ValueTask TestMultithreaded()
         {
-            fs.CreateDirectory("/dir1");
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.CreateDirectory("/dir1");
+            await fs.WriteAllText("/toto.txt", "content");
 
             const int CountTest = 200;
 
-            var thread1 = new Thread(() =>
+            var thread1 = new Thread(async () =>
             {
                 for (int i = 0; i < CountTest; i++)
                 {
-                    fs.CopyFile("/toto.txt", "/titi.txt", true);
-                    fs.MoveFile("/titi.txt", "/tata.txt");
-                    fs.MoveFile("/tata.txt", "/dir1/tata.txt");
+                    await fs.CopyFile("/toto.txt", "/titi.txt", true);
+                    await fs.MoveFile("/titi.txt", "/tata.txt");
+                    await fs.MoveFile("/tata.txt", "/dir1/tata.txt");
 
-                    if (fs.FileExists("/dir1/tata.txt"))
+                    if (await fs.FileExists("/dir1/tata.txt"))
                     {
-                        fs.DeleteFile("/dir1/tata.txt");
+                        await fs.DeleteFile("/dir1/tata.txt");
                     }
                 }
             });
-            var thread2 = new Thread(() =>
+            var thread2 = new Thread(async () =>
             {
                 for (int i = 0; i < CountTest; i++)
                 {
-                    fs.EnumeratePaths("/").ToList();
+                    (await fs.EnumeratePaths("/")).ToList();
                 }
             });
 
-            var thread3 = new Thread(() =>
+            var thread3 = new Thread(async () =>
             {
                 for (int i = 0; i < CountTest; i++)
                 {
-                    fs.CreateDirectory("/dir2");
-                    fs.MoveDirectory("/dir2", "/dir1/dir3");
-                    fs.DeleteDirectory("/dir1/dir3", true);
+                    await fs.CreateDirectory("/dir2");
+                    await fs.MoveDirectory("/dir2", "/dir1/dir3");
+                    await fs.DeleteDirectory("/dir1/dir3", true);
 
-                    fs.CreateFile("/0.txt").Dispose();
-                    fs.DeleteFile("/0.txt");
+                    (await fs.CreateFile("/0.txt")).Dispose();
+                    await fs.DeleteFile("/0.txt");
                 }
             });
 
@@ -593,82 +594,82 @@ namespace Zio.Tests.FileSystems
             thread2.Join();
             thread3.Join();
 
-            fs.DeleteDirectory("/dir1", true);
-            fs.DeleteFile("/toto.txt");
+            await fs.DeleteDirectory("/dir1", true);
+            await fs.DeleteFile("/toto.txt");
         }
 
         [Fact]
-        public void TestOpenFileAppendAndRead()
+        public async ValueTask TestOpenFileAppendAndRead()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            Assert.Throws<ArgumentException>(() =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                using (var stream = fs.OpenFile("/toto.txt", FileMode.Append, FileAccess.Read))
+                using (var stream = await fs.OpenFile("/toto.txt", FileMode.Append, FileAccess.Read))
                 {
                 }
             });
         }
 
         [Fact]
-        public void TestOpenFileCreateNewAlreadyExist()
+        public async ValueTask TestOpenFileCreateNewAlreadyExist()
         {
-            fs.WriteAllText("/toto.txt",  "content");
+            await fs.WriteAllText("/toto.txt",  "content");
 
-            Assert.Throws<IOException>(() =>
+            await Assert.ThrowsAsync<IOException>(async () =>
             {
-                using (var stream = fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write))
+                using (var stream = await fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write))
                 {
                 }
             });
 
-            Assert.Throws<IOException>(() =>
+            await Assert.ThrowsAsync<IOException>(async () =>
             {
-                using (var stream = fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite))
+                using (var stream = await fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite))
                 {
                 }
             });
         }
 
         [Fact]
-        public void TestOpenFileCreate()
+        public async ValueTask TestOpenFileCreate()
         {
-            fs.WriteAllText("/toto.txt", "content");
+            await fs.WriteAllText("/toto.txt", "content");
 
-            using (var stream = fs.OpenFile("/toto.txt", FileMode.Create, FileAccess.Write))
+            using (var stream = await fs.OpenFile("/toto.txt", FileMode.Create, FileAccess.Write))
             {
             }
 
-            Assert.Equal(0, fs.GetFileLength("/toto.txt"));
+            Assert.Equal(0, await fs.GetFileLength("/toto.txt"));
         }
 
         [Fact]
-        public void TestMoveDirectorySubFolderFail()
+        public async ValueTask TestMoveDirectorySubFolderFail()
         {
-            fs.CreateDirectory("/dir");
-            fs.CreateDirectory("/dir/dir1");
+            await fs.CreateDirectory("/dir");
+            await fs.CreateDirectory("/dir/dir1");
 
-            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir", "/dir/dir1/dir2"));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.MoveDirectory("/dir", "/dir/dir1/dir2"));
         }
 
         [Fact]
-        public void TestReplaceFileSameFileFail()
+        public async ValueTask TestReplaceFileSameFileFail()
         {
-            fs.WriteAllText("/toto.txt", "content");
-            Assert.Throws<IOException>(() => fs.ReplaceFile("/toto.txt", "/toto.txt", null, true));
+            await fs.WriteAllText("/toto.txt", "content");
+            await Assert.ThrowsAsync<IOException>(async () => await fs.ReplaceFile("/toto.txt", "/toto.txt", null, true));
 
-            fs.WriteAllText("/tata.txt", "content2");
+            await fs.WriteAllText("/tata.txt", "content2");
 
-            Assert.Throws<IOException>(() => fs.ReplaceFile("/toto.txt", "/tata.txt", "/toto.txt", true));
+            await Assert.ThrowsAsync<IOException>(async () => await fs.ReplaceFile("/toto.txt", "/tata.txt", "/toto.txt", true));
         }
 
         [Fact]
-        public void TestStreamSeek()
+        public async ValueTask TestStreamSeek()
         {
             //                            0123456
-            fs.WriteAllText("/toto.txt", "content", Encoding.ASCII);
+            await fs.WriteAllText("/toto.txt", "content", Encoding.ASCII);
 
-            using (var stream = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
+            using (var stream = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
             {
                 stream.Seek(0, SeekOrigin.Begin);
                 Assert.Equal((byte) 'c', stream.ReadByte());
@@ -691,10 +692,10 @@ namespace Zio.Tests.FileSystems
         }
 
         [Fact]
-        public void TestDispose()
+        public async ValueTask TestDispose()
         {
-            fs.WriteAllText("/toto.txt", "content");
-            var stream = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite);
+            await fs.WriteAllText("/toto.txt", "content");
+            var stream = await fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite);
             stream.Dispose();
             stream.Dispose();
 
@@ -711,28 +712,28 @@ namespace Zio.Tests.FileSystems
         }
 
         [Fact]
-        public void TestDeleteDirectoryNonEmpty()
+        public async ValueTask TestDeleteDirectoryNonEmpty()
         {
-            fs.CreateDirectory("/dir/dir1");
+            await fs.CreateDirectory("/dir/dir1");
             Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir", false));
         }
 
         [Fact]
-        public void TestInvalidCharacter()
+        public async ValueTask TestInvalidCharacter()
         {
-            Assert.Throws<NotSupportedException>(() => fs.CreateDirectory("/toto/ta:ta"));
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await fs.CreateDirectory("/toto/ta:ta"));
         }
 
         [Fact]
-        public void TestFileAttributes()
+        public async ValueTask TestFileAttributes()
         {
-            fs.WriteAllText("/toto.txt", "content");
-            fs.SetAttributes("/toto.txt", 0);
-            Assert.Equal(FileAttributes.Normal, fs.GetAttributes("/toto.txt"));
+            await fs.WriteAllText("/toto.txt", "content");
+            await fs.SetAttributes("/toto.txt", 0);
+            Assert.Equal(FileAttributes.Normal, await fs.GetAttributes("/toto.txt"));
 
-            fs.CreateDirectory("/dir");
-            fs.SetAttributes("/dir", 0);
-            Assert.Equal(FileAttributes.Directory, fs.GetAttributes("/dir"));
+            await fs.CreateDirectory("/dir");
+            await fs.SetAttributes("/dir", 0);
+            Assert.Equal(FileAttributes.Directory, await fs.GetAttributes("/dir"));
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestFileSystemExtensions.cs
+++ b/src/Zio.Tests/FileSystems/TestFileSystemExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 using Zio.FileSystems;
 
@@ -14,67 +15,67 @@ namespace Zio.Tests.FileSystems
     public class TestFileSystemExtensions : TestFileSystemBase
     {
         [Fact]
-        public void TestExceptions()
+        public async Task TestExceptions()
         {
             var fs = new MemoryFileSystem();
 
-            Assert.Throws<ArgumentNullException>(() => fs.AppendAllText("/a.txt", null));
-            Assert.Throws<ArgumentNullException>(() => fs.WriteAllText("/a.txt", null));
-            Assert.Throws<ArgumentNullException>(() => fs.WriteAllText("/a.txt", "content", null));
-            Assert.Throws<ArgumentNullException>(() => fs.WriteAllText("/a.txt", null, null));
-            Assert.Throws<ArgumentNullException>(() => fs.ReadAllText("/a.txt", null));
-            Assert.Throws<ArgumentNullException>(() => fs.ReadAllLines("/a.txt", null));
-            Assert.Throws<ArgumentNullException>(() => fs.WriteAllBytes("/a", null));
-            Assert.Throws<ArgumentNullException>(() => fs.AppendAllText("/a", null, null));
-            Assert.Throws<ArgumentNullException>(() => fs.AppendAllText("/a", "content", null));
-            Assert.Throws<ArgumentNullException>(() => fs.EnumeratePaths("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumeratePaths("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFiles("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFiles("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateDirectories("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateDirectories("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFileEntries("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFileEntries("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateDirectoryEntries("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateDirectoryEntries("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFileSystemEntries("*", null).First());
-            Assert.Throws<ArgumentNullException>(() => fs.EnumerateFileSystemEntries("*", null, SearchOption.AllDirectories).First());
-            Assert.Throws<FileNotFoundException>(() => fs.GetFileEntry("/a.txt"));
-            Assert.Throws<DirectoryNotFoundException>(() => fs.GetDirectoryEntry("/a"));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.AppendAllText("/a.txt", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.WriteAllText("/a.txt", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.WriteAllText("/a.txt", "content", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.WriteAllText("/a.txt", null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.ReadAllText("/a.txt", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.ReadAllLines("/a.txt", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.WriteAllBytes("/a", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.AppendAllText("/a", null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await fs.AppendAllText("/a", "content", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumeratePaths("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumeratePaths("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFiles("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFiles("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateDirectories("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateDirectories("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFileEntries("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFileEntries("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateDirectoryEntries("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateDirectoryEntries("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFileSystemEntries("*", null)).First());
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => (await fs.EnumerateFileSystemEntries("*", null, SearchOption.AllDirectories)).First());
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await fs.GetFileEntry("/a.txt"));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fs.GetDirectoryEntry("/a"));
         }
 
         [Fact]
-        public void TestWriteReadAppendAllTextAndLines()
+        public async Task TestWriteReadAppendAllTextAndLines()
         {
             var fs = new MemoryFileSystem();
-            fs.AppendAllText("/a.txt", "test");
-            fs.AppendAllText("/a.txt", "test");
-            Assert.Equal("testtest", fs.ReadAllText("/a.txt"));
+            await fs.AppendAllText("/a.txt", "test");
+            await fs.AppendAllText("/a.txt", "test");
+            Assert.Equal("testtest", await fs.ReadAllText("/a.txt"));
 
-            fs.WriteAllText("/a.txt", "content");
-            Assert.Equal("content", fs.ReadAllText("/a.txt"));
+            await fs.WriteAllText("/a.txt", "content");
+            Assert.Equal("content", await fs.ReadAllText("/a.txt"));
 
-            fs.WriteAllText("/a.txt", "test1", Encoding.UTF8);
-            fs.AppendAllText("/a.txt", "test2", Encoding.UTF8);
-            Assert.Equal("test1test2", fs.ReadAllText("/a.txt", Encoding.UTF8));
+            await fs.WriteAllText("/a.txt", "test1", Encoding.UTF8);
+            await fs.AppendAllText("/a.txt", "test2", Encoding.UTF8);
+            Assert.Equal("test1test2", await fs.ReadAllText("/a.txt", Encoding.UTF8));
 
-            Assert.Equal(new[] {"test1test2"}, fs.ReadAllLines("/a.txt"));
-            Assert.Equal(new[] { "test1test2" }, fs.ReadAllLines("/a.txt", Encoding.UTF8));
+            Assert.Equal(new[] {"test1test2"}, await fs.ReadAllLines("/a.txt"));
+            Assert.Equal(new[] { "test1test2" }, await fs.ReadAllLines("/a.txt", Encoding.UTF8));
         }
 
         [Fact]
-        public void TestReadWriteAllBytes()
+        public async Task TestReadWriteAllBytes()
         {
             var fs = new MemoryFileSystem();
 
-            fs.WriteAllBytes("/toto.txt", new byte[] {1,2,3});
-            Assert.Equal(new byte[]{1,2,3}, fs.ReadAllBytes("/toto.txt"));
+            await fs.WriteAllBytes("/toto.txt", new byte[] {1,2,3});
+            Assert.Equal(new byte[]{1,2,3}, await fs.ReadAllBytes("/toto.txt"));
 
-            fs.WriteAllBytes("/toto.txt", new byte[] { 5 });
-            Assert.Equal(new byte[] { 5 }, fs.ReadAllBytes("/toto.txt"));
+            await fs.WriteAllBytes("/toto.txt", new byte[] { 5 });
+            Assert.Equal(new byte[] { 5 }, await fs.ReadAllBytes("/toto.txt"));
 
-            fs.WriteAllBytes("/toto.txt", new byte[] { });
-            Assert.Equal(new byte[] { }, fs.ReadAllBytes("/toto.txt"));
+            await fs.WriteAllBytes("/toto.txt", new byte[] { });
+            Assert.Equal(new byte[] { }, await fs.ReadAllBytes("/toto.txt"));
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Zio.FileSystems;
 
@@ -11,42 +12,42 @@ namespace Zio.Tests.FileSystems
     public class TestMemoryFileSystem : TestFileSystemBase
     {
         [Fact]
-        public void TestCommonRead()
+        public async ValueTask TestCommonRead()
         {
-            var fs = GetCommonMemoryFileSystem();
-            AssertCommonRead(fs);
+            var fs = await GetCommonMemoryFileSystem();
+            await AssertCommonRead(fs);
         }
 
         [Fact]
-        public void TestCopyFileSystem()
+        public async ValueTask TestCopyFileSystem()
         {
-            var fs = GetCommonMemoryFileSystem();
+            var fs = await GetCommonMemoryFileSystem();
 
             var dest = new MemoryFileSystem();
-            fs.CopyTo(dest, UPath.Root, true);
+            await fs.CopyTo(dest, UPath.Root, true);
 
-            AssertFileSystemEqual(fs, dest);
+            await AssertFileSystemEqual(fs, dest);
         }
 
         [Fact]
-        public void TestCopyFileSystemSubFolder()
+        public async ValueTask TestCopyFileSystemSubFolder()
         {
-            var fs = GetCommonMemoryFileSystem();
+            var fs = await GetCommonMemoryFileSystem();
 
             var dest = new MemoryFileSystem();
             var subFolder = UPath.Root / "subfolder";
-            fs.CopyTo(dest, subFolder, true);
+            await fs.CopyTo(dest, subFolder, true);
 
-            var destSubFileSystem = dest.GetOrCreateSubFileSystem(subFolder);
-            
-            AssertFileSystemEqual(fs, destSubFileSystem);
+            var destSubFileSystem = await dest.GetOrCreateSubFileSystem(subFolder);
+
+            await AssertFileSystemEqual(fs, destSubFileSystem);
         }
         
 
         [Fact]
-        public void TestWatcher()
+        public async ValueTask TestWatcher()
         {
-            var fs = GetCommonMemoryFileSystem();
+            var fs = await GetCommonMemoryFileSystem();
             var watcher = fs.Watch("/a");
 
             var gotChange = false;
@@ -61,18 +62,18 @@ namespace Zio.Tests.FileSystems
             watcher.IncludeSubdirectories = true;
             watcher.EnableRaisingEvents = true;
 
-            fs.WriteAllText("/a/watched.txt", "test");
+            await fs.WriteAllText("/a/watched.txt", "test");
             System.Threading.Thread.Sleep(100);
             Assert.True(gotChange);
         }
 
         [Fact]
-        public void TestDispose()
+        public async ValueTask TestDispose()
         {
             var memfs = new MemoryFileSystem();
 
             memfs.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => memfs.DirectoryExists("/"));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await memfs.DirectoryExists("/"));
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestMountFileSystemCompatSub.cs
+++ b/src/Zio.Tests/FileSystems/TestMountFileSystemCompatSub.cs
@@ -14,7 +14,7 @@ namespace Zio.Tests.FileSystems
             mountfs.Mount("/customMount", new MemoryFileSystem());
 
             // Use a SubFileSystem to fake the mount to a root folder
-            fs = new SubFileSystem(mountfs, "/customMount");
+            fs = SubFileSystem.Create(mountfs, "/customMount").GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystemCompat.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystemCompat.cs
@@ -16,7 +16,7 @@ namespace Zio.Tests.FileSystems
 
         public TestPhysicalFileSystemCompat()
         {
-            _fsHelper = new PhysicalDirectoryHelper(SystemPath);
+            _fsHelper = PhysicalDirectoryHelper.Create(SystemPath).GetAwaiter().GetResult();
             fs = _fsHelper.PhysicalFileSystem;
         }
 

--- a/src/Zio.Tests/FileSystems/TestReadOnlyFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestReadOnlyFileSystem.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using System.Threading.Tasks;
 using Xunit;
 using Zio.FileSystems;
 
@@ -10,10 +11,10 @@ namespace Zio.Tests.FileSystems
     public class TestReadOnlyFileSystem : TestFileSystemBase
     {
         [Fact]
-        public void TestCommonReadOnly()
+        public async Task TestCommonReadOnly()
         {
-            var rofs = new ReadOnlyFileSystem(GetCommonMemoryFileSystem());
-            AssertCommonReadOnly(rofs);
+            var rofs = new ReadOnlyFileSystem(await GetCommonMemoryFileSystem());
+            await AssertCommonReadOnly(rofs);
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Zio.FileSystems;
 
@@ -13,45 +14,45 @@ namespace Zio.Tests.FileSystems
     public class TestSubFileSystem : TestFileSystemBase
     {
         [Fact]
-        public void TestBasic()
+        public async Task TestBasic()
         {
             var fs = new PhysicalFileSystem();
             var path = fs.ConvertPathFromInternal(SystemPath);
 
             // Create a filesystem / on the current folder of this assembly
-            var subfs = new SubFileSystem(fs, path);
+            var subfs = await SubFileSystem.Create(fs, path);
 
             // This test is basically testing the two methods (ConvertPathToDelegate and ConvertPathFromDelegate) in SubFileSystem
 
-            var files = subfs.EnumeratePaths("/").Select(info => info.GetName()).ToList();
-            var expectedFiles = fs.EnumeratePaths(path).Select(info => info.GetName()).ToList();
+            var files = (await subfs.EnumeratePaths("/")).Select(info => info.GetName()).ToList();
+            var expectedFiles = (await fs.EnumeratePaths(path)).Select(info => info.GetName()).ToList();
             Assert.True(files.Count > 0);
             Assert.Equal(expectedFiles, files);
 
             // Check that SubFileSystem is actually checking that the directory exists in the delegate filesystem
-            Assert.Throws<DirectoryNotFoundException>(() => new SubFileSystem(fs, path / "does_not_exist"));
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await SubFileSystem.Create(fs, path / "does_not_exist"));
 
             Assert.Throws<InvalidOperationException>(() => subfs.ConvertPathFromInternal(@"C:\"));
             // TODO: We could add another test just to make sure that files can be created...etc. But the test above should already cover the code provided in SubFileSystem
         }
 
         [Fact]
-        public void TestGetOrCreateFileSystem()
+        public async Task TestGetOrCreateFileSystem()
         {
             var fs = new MemoryFileSystem();
             const string subFolder = "/sub";
-            var subFileSystem = fs.GetOrCreateSubFileSystem(subFolder);
-            Assert.True(fs.DirectoryExists(subFolder));
-            subFileSystem.WriteAllText("/test.txt", "yo");
-            var text = fs.ReadAllText(subFolder + "/test.txt");
+            var subFileSystem = await fs.GetOrCreateSubFileSystem(subFolder);
+            Assert.True(await fs.DirectoryExists(subFolder));
+            await subFileSystem.WriteAllText("/test.txt", "yo");
+            var text = await fs.ReadAllText(subFolder + "/test.txt");
             Assert.Equal("yo", text);
         }
 
         [Fact]
-        public void TestWatcher()
+        public async Task TestWatcher()
         {
-            var fs = GetCommonMemoryFileSystem();
-            var subFs = fs.GetOrCreateSubFileSystem("/a/b");
+            var fs = await GetCommonMemoryFileSystem();
+            var subFs = await fs.GetOrCreateSubFileSystem("/a/b");
             var watcher = subFs.Watch("/");
 
             var gotChange = false;
@@ -66,7 +67,7 @@ namespace Zio.Tests.FileSystems
             watcher.IncludeSubdirectories = true;
             watcher.EnableRaisingEvents = true;
 
-            fs.WriteAllText("/a/b/watched.txt", "test");
+            await fs.WriteAllText("/a/b/watched.txt", "test");
             System.Threading.Thread.Sleep(100);
             Assert.True(gotChange);
         }

--- a/src/Zio.Tests/Zio.Tests.csproj
+++ b/src/Zio.Tests/Zio.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Zio/DirectoryEntry.cs
+++ b/src/Zio/DirectoryEntry.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Zio
 {
@@ -24,9 +25,9 @@ namespace Zio
 
         /// <summary>Creates a directory.</summary>
         /// <exception cref="T:System.IO.IOException">The directory cannot be created. </exception>
-        public void Create()
+        public ValueTask Create()
         {
-            FileSystem.CreateDirectory(Path);
+            return FileSystem.CreateDirectory(Path);
         }
 
         /// <summary>Creates a subdirectory or subdirectories on the specified path. The specified path can be relative to this instance of the <see cref="T:System.IO.DirectoryInfo" /> class.</summary>
@@ -42,7 +43,7 @@ namespace Zio
         /// <exception cref="T:System.Security.SecurityException">The caller does not have code access permission to create the directory.-or-The caller does not have code access permission to read the directory described by the returned <see cref="T:System.IO.DirectoryInfo" /> object.  This can occur when the <paramref name="path" /> parameter describes an existing directory.</exception>
         /// <exception cref="T:System.NotSupportedException">
         /// <paramref name="path" /> contains a colon character (:) that is not part of a drive label ("C:\").</exception>
-        public DirectoryEntry CreateSubdirectory(UPath path)
+        public async ValueTask<DirectoryEntry> CreateSubdirectory(UPath path)
         {
             if (!path.IsRelative)
             {
@@ -51,7 +52,7 @@ namespace Zio
 
             // Check that path is not null and relative
             var subPath = new DirectoryEntry(FileSystem, Path / path);
-            subPath.Create();
+            await subPath.Create();
             return subPath;
         }
 
@@ -61,9 +62,9 @@ namespace Zio
         /// <exception cref="T:System.IO.DirectoryNotFoundException">The directory described by this <see cref="T:System.IO.DirectoryInfo" /> object does not exist or could not be found.</exception>
         /// <exception cref="T:System.IO.IOException">The directory is read-only.-or- The directory contains one or more files or subdirectories and <paramref name="recursive" /> is false.-or-The directory is the application's current working directory. -or-There is an open handle on the directory or on one of its files, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories and files. For more information, see How to: Enumerate Directories and Files.</exception>
         /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission. </exception>
-        public void Delete(bool recursive)
+        public ValueTask Delete(bool recursive)
         {
-            FileSystem.DeleteDirectory(Path, recursive);
+            return FileSystem.DeleteDirectory(Path, recursive);
         }
 
         /// <summary>Returns an enumerable collection of directory information that matches a specified search pattern and search subdirectory option. </summary>
@@ -75,7 +76,7 @@ namespace Zio
         /// <returns>An enumerable collection of directories.</returns>
         /// <exception cref="T:System.IO.DirectoryNotFoundException">The path encapsulated in the <see cref="T:System.IO.DirectoryInfo" /> object is invalid (for example, it is on an unmapped drive). </exception>
         /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission. </exception>
-        public IEnumerable<DirectoryEntry> EnumerateDirectories(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        public ValueTask<IEnumerable<DirectoryEntry>> EnumerateDirectories(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return FileSystem.EnumerateDirectoryEntries(Path, searchPattern, searchOption);
         }
@@ -89,7 +90,7 @@ namespace Zio
         /// <returns>An enumerable collection of files.</returns>
         /// <exception cref="T:System.IO.DirectoryNotFoundException">The path encapsulated in the <see cref="T:System.IO.DirectoryInfo" /> object is invalid (for example, it is on an unmapped drive). </exception>
         /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission. </exception>
-        public IEnumerable<FileEntry> EnumerateFiles(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        public ValueTask<IEnumerable<FileEntry>> EnumerateFiles(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return FileSystem.EnumerateFileEntries(Path, searchPattern, searchOption);
         }
@@ -104,7 +105,7 @@ namespace Zio
         /// The default value is TopDirectoryOnly.</param>
         /// <param name="searchTarget">The search target either <see cref="SearchTarget.Both"/> or only <see cref="SearchTarget.Directory"/> or <see cref="SearchTarget.File"/>.</param>
         /// <returns>An enumerable collection of <see cref="FileSystemEntry"/> that match a search pattern in a specified path.</returns>
-        public IEnumerable<FileSystemEntry> EnumerateEntries(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly, SearchTarget searchTarget = SearchTarget.Both)
+        public ValueTask<IEnumerable<FileSystemEntry>> EnumerateEntries(string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly, SearchTarget searchTarget = SearchTarget.Both)
         {
             return FileSystem.EnumerateFileSystemEntries(Path, searchPattern, searchOption, searchTarget);
         }
@@ -115,7 +116,7 @@ namespace Zio
         /// <param name="searchPredicate">The search string to match against file-system entries in path. This parameter can contain a combination of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory or should include all subdirectories.</param>
         /// <returns>An enumerable collection of <see cref="FileSystemItem"/> in the directory specified by path and that match the specified search pattern, option and target.</returns>
-        public IEnumerable<FileSystemItem> EnumerateItems(SearchOption searchOption = SearchOption.TopDirectoryOnly, SearchPredicate? searchPredicate = null)
+        public ValueTask<IEnumerable<FileSystemItem>> EnumerateItems(SearchOption searchOption = SearchOption.TopDirectoryOnly, SearchPredicate? searchPredicate = null)
         {
             return FileSystem.EnumerateItems(Path, searchOption, searchPredicate);
         }
@@ -129,18 +130,18 @@ namespace Zio
         /// <exception cref="T:System.IO.IOException">An attempt was made to move a directory to a different volume. -or-<paramref name="destDirName" /> already exists.-or-You are not authorized to access this path.-or- The directory being moved and the destination directory have the same name.</exception>
         /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission. </exception>
         /// <exception cref="T:System.IO.DirectoryNotFoundException">The destination directory cannot be found.</exception>
-        public void MoveTo(UPath destDirName)
+        public ValueTask MoveTo(UPath destDirName)
         {
-            FileSystem.MoveDirectory(Path, destDirName);
+            return FileSystem.MoveDirectory(Path, destDirName);
         }
 
         /// <inheritdoc />
-        public override bool Exists => FileSystem.DirectoryExists(Path);
+        public override ValueTask<bool> Exists => FileSystem.DirectoryExists(Path);
 
         /// <inheritdoc />
-        public override void Delete()
+        public override ValueTask Delete()
         {
-            Delete(true);
+            return Delete(true);
         }
     }
 }

--- a/src/Zio/FileSystemEntry.cs
+++ b/src/Zio/FileSystemEntry.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Zio
 {
@@ -56,47 +57,20 @@ namespace Zio
         public string? ExtensionWithDot => Path.GetExtensionWithDot();
 
         /// <summary>
-        /// Gets or sets the attributes for the current file or directory
+        /// Gets the attributes for the current file or directory
         /// </summary>
-        public FileAttributes Attributes
-        {
-            get => FileSystem.GetAttributes(Path);
-
-            set => FileSystem.SetAttributes(Path, value);
-        }
+        public ValueTask<FileAttributes> GetAttributes() => FileSystem.GetAttributes(Path);
+        
+        /// <summary>
+        /// Sets the attributes for the current file or directory
+        /// </summary>
+        public ValueTask SetAttributes(FileAttributes value) => FileSystem.SetAttributes(Path, value);        
 
         /// <summary>
         /// Gets a value indicating whether this file or directory exists.
         /// </summary>
         /// <value><c>true</c> if this file or directory exists; otherwise, <c>false</c>.</value>
-        public abstract bool Exists { get; }
-
-        /// <summary>
-        /// Gets or sets the creation time of the current file or directory.
-        /// </summary>
-        public DateTime CreationTime
-        {
-            get => FileSystem.GetCreationTime(Path);
-            set => FileSystem.SetCreationTime(Path, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the last access time of the current file or directory.
-        /// </summary>
-        public DateTime LastAccessTime
-        {
-            get => FileSystem.GetLastAccessTime(Path);
-            set => FileSystem.SetLastAccessTime(Path, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the last write time of the current file or directory.
-        /// </summary>
-        public DateTime LastWriteTime
-        {
-            get => FileSystem.GetLastWriteTime(Path);
-            set => FileSystem.SetLastWriteTime(Path, value);
-        }
+        public abstract ValueTask<bool> Exists { get; }
 
         /// <summary>Gets an instance of the parent directory.</summary>
         /// <returns>A <see cref="DirectoryEntry" /> object representing the parent directory of this file.</returns>
@@ -109,7 +83,7 @@ namespace Zio
         /// <summary>
         /// Deletes a file or directory.
         /// </summary>
-        public abstract void Delete();
+        public abstract ValueTask Delete();
 
         /// <summary>
         /// Returns the <see cref="FullName"/> of this instance.
@@ -121,7 +95,7 @@ namespace Zio
         }
 
         /// <inheritdoc />
-        public bool Equals(FileSystemEntry other)
+        public bool Equals(FileSystemEntry? other)
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;

--- a/src/Zio/FileSystemExtensions.cs
+++ b/src/Zio/FileSystemExtensions.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Zio.FileSystems;
 using static Zio.FileSystemExceptionHelper;
 
@@ -22,12 +24,13 @@ namespace Zio
         /// <param name="fs">The filesystem to derive a new sub-filesystem from it</param>
         /// <param name="subFolder">The folder of the sub-filesystem</param>
         /// <returns>A sub-filesystem</returns>
-        public static SubFileSystem GetOrCreateSubFileSystem(this IFileSystem fs, UPath subFolder)
+        public static async ValueTask<SubFileSystem> GetOrCreateSubFileSystem(this IFileSystem fs, UPath subFolder)
         {
-            if (!fs.DirectoryExists(subFolder))
+            if (!await fs.DirectoryExists(subFolder))
             {
-                fs.CreateDirectory(subFolder);
+                await fs.CreateDirectory(subFolder);
             }
+
             return new SubFileSystem(fs, subFolder);
         }
 
@@ -41,9 +44,9 @@ namespace Zio
         /// <remarks>
         /// By default, this method copy attributes from source files. Use the overload method to disable this.
         /// </remarks>
-        public static void CopyTo(this IFileSystem fs, IFileSystem destFileSystem, UPath dstFolder, bool overwrite)
+        public static Task CopyTo(this IFileSystem fs, IFileSystem destFileSystem, UPath dstFolder, bool overwrite)
         {
-            CopyTo(fs, destFileSystem, dstFolder, overwrite, true);
+            return CopyTo(fs, destFileSystem, dstFolder, overwrite, true);
         }
 
         /// <summary>
@@ -54,11 +57,11 @@ namespace Zio
         /// <param name="dstFolder">The destination folder in the destination filesystem.</param>
         /// <param name="overwrite"><c>true</c> to overwrite files.</param>
         /// <param name="copyAttributes">`true` to copy the attributes of the source file system if filesystem source and destination are different, false otherwise.</param>
-        public static void CopyTo(this IFileSystem fs, IFileSystem destFileSystem, UPath dstFolder, bool overwrite, bool copyAttributes)
+        public static Task CopyTo(this IFileSystem fs, IFileSystem destFileSystem, UPath dstFolder, bool overwrite, bool copyAttributes)
         {
             if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
 
-            CopyDirectory(fs, UPath.Root, destFileSystem, dstFolder, overwrite, copyAttributes);
+            return CopyDirectory(fs, UPath.Root, destFileSystem, dstFolder, overwrite, copyAttributes);
         }
 
         /// <summary>
@@ -72,9 +75,9 @@ namespace Zio
         /// <remarks>
         /// By default, this method copy attributes from source files. Use the overload method to disable this.
         /// </remarks>
-        public static void CopyDirectory(this IFileSystem fs, UPath srcFolder, IFileSystem destFileSystem, UPath dstFolder, bool overwrite)
+        public static Task CopyDirectory(this IFileSystem fs, UPath srcFolder, IFileSystem destFileSystem, UPath dstFolder, bool overwrite)
         {
-            CopyDirectory(fs, srcFolder, destFileSystem, dstFolder, overwrite, true);
+            return CopyDirectory(fs, srcFolder, destFileSystem, dstFolder, overwrite, true);
         }
 
         /// <summary>
@@ -86,15 +89,15 @@ namespace Zio
         /// <param name="dstFolder">The destination folder in the destination filesystem.</param>
         /// <param name="overwrite"><c>true</c> to overwrite files.</param>
         /// <param name="copyAttributes">`true` to copy the attributes of the source file system if filesystem source and destination are different, false otherwise.</param>
-        public static void CopyDirectory(this IFileSystem fs, UPath srcFolder, IFileSystem destFileSystem, UPath dstFolder, bool overwrite, bool copyAttributes)
+        public static async Task CopyDirectory(this IFileSystem fs, UPath srcFolder, IFileSystem destFileSystem, UPath dstFolder, bool overwrite, bool copyAttributes)
         {
             if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
 
-            if (!fs.DirectoryExists(srcFolder)) throw new DirectoryNotFoundException($"{srcFolder} folder not found from source file system.");
+            if (!await fs.DirectoryExists(srcFolder)) throw new DirectoryNotFoundException($"{srcFolder} folder not found from source file system.");
 
             if (dstFolder != UPath.Root)
             {
-                destFileSystem.CreateDirectory(dstFolder);
+                await destFileSystem.CreateDirectory(dstFolder);
             }
 
             var srcFolderFullName = srcFolder.FullName;
@@ -102,21 +105,21 @@ namespace Zio
             int deltaSubString = srcFolder == UPath.Root ? 0 : 1;
 
             // Copy the files for the folder
-            foreach (var file in fs.EnumerateFiles(srcFolder))
+            foreach (var file in await fs.EnumerateFiles(srcFolder))
             {
                 var relativeFile = file.FullName.Substring(srcFolderFullName.Length + deltaSubString);
                 var destFile = UPath.Combine(dstFolder, relativeFile);
 
-                fs.CopyFileCross(file, destFileSystem, destFile, overwrite, copyAttributes);
+                await fs.CopyFileCross(file, destFileSystem, destFile, overwrite, copyAttributes);
             }
 
             // Then copy the folder structure recursively
-            foreach (var srcSubFolder in fs.EnumerateDirectories(srcFolder))
+            foreach (var srcSubFolder in await fs.EnumerateDirectories(srcFolder))
             {
                 var relativeDestFolder = srcSubFolder.FullName.Substring(srcFolderFullName.Length + deltaSubString);
 
                 var destSubFolder = UPath.Combine(dstFolder, relativeDestFolder);
-                CopyDirectory(fs, srcSubFolder, destFileSystem, destSubFolder, overwrite, copyAttributes);
+                await CopyDirectory(fs, srcSubFolder, destFileSystem, destSubFolder, overwrite, copyAttributes);
             }
         }
 
@@ -131,9 +134,9 @@ namespace Zio
         /// <remarks>
         /// By default, this method copy attributes from source files. Use the overload method to disable this.
         /// </remarks>
-        public static void CopyFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath, bool overwrite)
+        public static Task CopyFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath, bool overwrite)
         {
-            CopyFileCross(fs, srcPath, destFileSystem, destPath, overwrite, true);
+            return CopyFileCross(fs, srcPath, destFileSystem, destPath, overwrite, true);
         }
 
         /// <summary>
@@ -145,53 +148,53 @@ namespace Zio
         /// <param name="destPath">The destination path of the file in the destination filesystem</param>
         /// <param name="overwrite"><c>true</c> to overwrite an existing destination file</param>
         /// <param name="copyAttributes">`true` to copy the attributes of the source file system if filesystem source and destination are different, false otherwise.</param>
-        public static void CopyFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath, bool overwrite, bool copyAttributes)
+        public static async Task CopyFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath, bool overwrite, bool copyAttributes)
         {
             if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
 
             // If this is the same filesystem, use the file system directly to perform the action
             if (fs == destFileSystem)
             {
-                fs.CopyFile(srcPath, destPath, overwrite);
+                await fs.CopyFile(srcPath, destPath, overwrite);
                 return;
             }
 
             srcPath.AssertAbsolute(nameof(srcPath));
-            if (!fs.FileExists(srcPath))
+            if (!await fs.FileExists(srcPath))
             {
                 throw NewFileNotFoundException(srcPath);
             }
 
             destPath.AssertAbsolute(nameof(destPath));
             var destDirectory = destPath.GetDirectory();
-            if (!destFileSystem.DirectoryExists(destDirectory))
+            if (!await destFileSystem.DirectoryExists(destDirectory))
             {
                 throw NewDirectoryNotFoundException(destDirectory);
             }
 
-            if (destFileSystem.FileExists(destPath) && !overwrite)
+            if (await destFileSystem.FileExists(destPath) && !overwrite)
             {
                 throw new IOException($"The destination file path `{destPath}` already exist and overwrite is false");
             }
 
-            using (var sourceStream = fs.OpenFile(srcPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var sourceStream = await fs.OpenFile(srcPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 var copied = false;
                 try
                 {
-                    using (var destStream = destFileSystem.OpenFile(destPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    using (var destStream = await destFileSystem.OpenFile(destPath, FileMode.Create, FileAccess.Write, FileShare.Read))
                     {
-                        sourceStream.CopyTo(destStream);
+                        await sourceStream.CopyToAsync(destStream);
                     }
 
                     if (copyAttributes)
                     {
                         // NOTE: For some reasons, we can sometimes get an Unauthorized access if we try to set the LastWriteTime after the SetAttributes
                         // So we setup it here.
-                        destFileSystem.SetLastWriteTime(destPath, fs.GetLastWriteTime(srcPath));
+                        await destFileSystem.SetLastWriteTime(destPath, await fs.GetLastWriteTime(srcPath));
 
                         // Preserve attributes and LastWriteTime as a regular File.Copy
-                        destFileSystem.SetAttributes(destPath, fs.GetAttributes(srcPath));
+                        await destFileSystem.SetAttributes(destPath, await fs.GetAttributes(srcPath));
                     }
 
                     copied = true;
@@ -202,7 +205,7 @@ namespace Zio
                     {
                         try
                         {
-                            destFileSystem.DeleteFile(destPath);
+                            await destFileSystem.DeleteFile(destPath);
                         }
                         catch
                         {
@@ -220,20 +223,20 @@ namespace Zio
         /// <param name="srcPath">The source path of the file to move from the source filesystem</param>
         /// <param name="destFileSystem">The destination filesystem</param>
         /// <param name="destPath">The destination path of the file in the destination filesystem</param>
-        public static void MoveFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath)
+        public static async Task MoveFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath)
         {
             if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
 
             // If this is the same filesystem, use the file system directly to perform the action
             if (fs == destFileSystem)
             {
-                fs.MoveFile(srcPath, destPath);
+                await fs.MoveFile(srcPath, destPath);
                 return;
             }
 
             // Check source
             srcPath.AssertAbsolute(nameof(srcPath));
-            if (!fs.FileExists(srcPath))
+            if (!await fs.FileExists(srcPath))
             {
                 throw NewFileNotFoundException(srcPath);
             }
@@ -241,36 +244,36 @@ namespace Zio
             // Check destination
             destPath.AssertAbsolute(nameof(destPath));
             var destDirectory = destPath.GetDirectory();
-            if (!destFileSystem.DirectoryExists(destDirectory))
+            if (!await destFileSystem.DirectoryExists(destDirectory))
             {
                 throw NewDirectoryNotFoundException(destPath);
             }
 
-            if (destFileSystem.DirectoryExists(destPath))
+            if (await destFileSystem.DirectoryExists(destPath))
             {
                 throw NewDestinationDirectoryExistException(destPath);
             }
 
-            if (destFileSystem.FileExists(destPath))
+            if (await destFileSystem.FileExists(destPath))
             {
                 throw NewDestinationFileExistException(destPath);
             }
 
-            using (var sourceStream = fs.OpenFile(srcPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var sourceStream = await fs.OpenFile(srcPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 var copied = false;
                 try
                 {
-                    using (var destStream = destFileSystem.OpenFile(destPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    using (var destStream = await destFileSystem.OpenFile(destPath, FileMode.Create, FileAccess.Write, FileShare.Read))
                     {
-                        sourceStream.CopyTo(destStream);
+                        await sourceStream.CopyToAsync(destStream);
                     }
 
                     // Preserve all attributes and times
-                    destFileSystem.SetAttributes(destPath, fs.GetAttributes(srcPath));
-                    destFileSystem.SetCreationTime(destPath, fs.GetCreationTime(srcPath));
-                    destFileSystem.SetLastAccessTime(destPath, fs.GetLastAccessTime(srcPath));
-                    destFileSystem.SetLastWriteTime(destPath, fs.GetLastWriteTime(srcPath));
+                    await destFileSystem.SetAttributes(destPath, await fs.GetAttributes(srcPath));
+                    await destFileSystem.SetCreationTime(destPath, await fs.GetCreationTime(srcPath));
+                    await destFileSystem.SetLastAccessTime(destPath, await fs.GetLastAccessTime(srcPath));
+                    await destFileSystem.SetLastWriteTime(destPath, await fs.GetLastWriteTime(srcPath));
                     copied = true;
                 }
                 finally
@@ -279,7 +282,7 @@ namespace Zio
                     {
                         try
                         {
-                            destFileSystem.DeleteFile(destPath);
+                            await destFileSystem.DeleteFile(destPath);
                         }
                         catch
                         {
@@ -292,7 +295,7 @@ namespace Zio
             var deleted = false;
             try
             {
-                fs.DeleteFile(srcPath);
+                await fs.DeleteFile(srcPath);
                 deleted = true;
             }
             finally
@@ -301,7 +304,7 @@ namespace Zio
                 {
                     try
                     {
-                        destFileSystem.DeleteFile(destPath);
+                        await destFileSystem.DeleteFile(destPath);
                     }
                     catch
                     {
@@ -317,12 +320,12 @@ namespace Zio
         /// <param name="fs">The filesystem.</param>
         /// <param name="path">The path of the file to open for reading.</param>
         /// <returns>A byte array containing the contents of the file.</returns>
-        public static byte[] ReadAllBytes(this IFileSystem fs, UPath path)
+        public static async Task<byte[]> ReadAllBytes(this IFileSystem fs, UPath path)
         {
             var memstream = new MemoryStream();
-            using (var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var stream = await fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                stream.CopyTo(memstream);
+                await stream.CopyToAsync(memstream);
             }
             return memstream.ToArray();
         }
@@ -337,13 +340,13 @@ namespace Zio
         ///     This method attempts to automatically detect the encoding of a file based on the presence of byte order marks.
         ///     Encoding formats UTF-8 and UTF-32 (both big-endian and little-endian) can be detected.
         /// </remarks>
-        public static string ReadAllText(this IFileSystem fs, UPath path)
+        public static async Task<string> ReadAllText(this IFileSystem fs, UPath path)
         {
-            var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return reader.ReadToEnd();
+                    return await reader.ReadToEndAsync();
                 }
             }
         }
@@ -355,14 +358,14 @@ namespace Zio
         /// <param name="path">The path of the file to open for reading.</param>
         /// <param name="encoding">The encoding to use to decode the text from <paramref name="path" />.</param>
         /// <returns>A string containing all lines of the file.</returns>
-        public static string ReadAllText(this IFileSystem fs, UPath path, Encoding encoding)
+        public static async Task<string> ReadAllText(this IFileSystem fs, UPath path, Encoding encoding)
         {
             if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-            var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             {
                 using (var reader = new StreamReader(stream, encoding))
                 {
-                    return reader.ReadToEnd();
+                    return await reader.ReadToEndAsync();
                 }
             }
         }
@@ -379,12 +382,12 @@ namespace Zio
         ///     Given a byte array and a file path, this method opens the specified file, writes the
         ///     contents of the byte array to the file, and then closes the file.
         /// </remarks>
-        public static void WriteAllBytes(this IFileSystem fs, UPath path, byte[] content)
+        public static async Task WriteAllBytes(this IFileSystem fs, UPath path, byte[] content)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
-            using (var stream = fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (var stream = await fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read))
             {
-                stream.Write(content, 0, content.Length);
+                await stream.WriteAsync(content, 0, content.Length);
             }
         }
 
@@ -394,15 +397,15 @@ namespace Zio
         /// <param name="fs">The filesystem.</param>
         /// <param name="path">The path of the file to open for reading.</param>
         /// <returns>An array of strings containing all lines of the file.</returns>
-        public static string[] ReadAllLines(this IFileSystem fs, UPath path)
+        public static async Task<string[]> ReadAllLines(this IFileSystem fs, UPath path)
         {
-            var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             {
                 using (var reader = new StreamReader(stream))
                 {
                     var lines = new List<string>();
                     string line;
-                    while ((line = reader.ReadLine()) != null)
+                    while ((line = await reader.ReadLineAsync()) != null)
                     {
                         lines.Add(line);
                     }
@@ -422,16 +425,16 @@ namespace Zio
         ///     Encoding formats UTF-8 and UTF-32 (both big-endian and little-endian) can be detected.
         /// </remarks>
         /// <returns>An array of strings containing all lines of the file.</returns>
-        public static string[] ReadAllLines(this IFileSystem fs, UPath path, Encoding encoding)
+        public static async Task<string[]> ReadAllLines(this IFileSystem fs, UPath path, Encoding encoding)
         {
             if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-            var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             {
                 using (var reader = new StreamReader(stream, encoding))
                 {
                     var lines = new List<string>();
                     string line;
-                    while ((line = reader.ReadLine()) != null)
+                    while ((line = await reader.ReadLineAsync()) != null)
                     {
                         lines.Add(line);
                     }
@@ -454,15 +457,15 @@ namespace Zio
         ///     If it is necessary to include a UTF-8 identifier, such as a byte order mark, at the beginning of a file,
         ///     use the <see cref="WriteAllText(Zio.IFileSystem,Zio.UPath,string, Encoding)" /> method overload with UTF8 encoding.
         /// </remarks>
-        public static void WriteAllText(this IFileSystem fs, UPath path, string content)
+        public static async Task WriteAllText(this IFileSystem fs, UPath path, string content)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
-            var stream = fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read);
             {
                 using (var writer = new StreamWriter(stream))
                 {
-                    writer.Write(content);
-                    writer.Flush();
+                    await writer.WriteAsync(content);
+                    await writer.FlushAsync();
                 }
             }
         }
@@ -481,16 +484,16 @@ namespace Zio
         ///     specified encoding, and then closes the file.
         ///     The file handle is guaranteed to be closed by this method, even if exceptions are raised.
         /// </remarks>
-        public static void WriteAllText(this IFileSystem fs, UPath path, string content, Encoding encoding)
+        public static async Task WriteAllText(this IFileSystem fs, UPath path, string content, Encoding encoding)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
             if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-            var stream = fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read);
             {
                 using (var writer = new StreamWriter(stream, encoding))
                 {
-                    writer.Write(content);
-                    writer.Flush();
+                    await writer.WriteAsync(content);
+                    await writer.FlushAsync();
                 }
             }
         }
@@ -509,15 +512,15 @@ namespace Zio
         ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
         ///     path parameter must contain existing directories.
         /// </remarks>
-        public static void AppendAllText(this IFileSystem fs, UPath path, string content)
+        public static async Task AppendAllText(this IFileSystem fs, UPath path, string content)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
-            var stream = fs.OpenFile(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Append, FileAccess.Write, FileShare.Read);
             {
                 using (var writer = new StreamWriter(stream))
                 {
-                    writer.Write(content);
-                    writer.Flush();
+                    await writer.WriteAsync(content);
+                    await writer.FlushAsync();
                 }
             }
         }
@@ -536,16 +539,16 @@ namespace Zio
         ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
         ///     path parameter must contain existing directories.
         /// </remarks>
-        public static void AppendAllText(this IFileSystem fs, UPath path, string content, Encoding encoding)
+        public static async Task AppendAllText(this IFileSystem fs, UPath path, string content, Encoding encoding)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
             if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-            var stream = fs.OpenFile(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var stream = await fs.OpenFile(path, FileMode.Append, FileAccess.Write, FileShare.Read);
             {
                 using (var writer = new StreamWriter(stream, encoding))
                 {
-                    writer.Write(content);
-                    writer.Flush();
+                    await writer.WriteAsync(content);
+                    await writer.FlushAsync();
                 }
             }
         }
@@ -556,7 +559,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path and name of the file to create.</param>
         /// <returns>A stream that provides read/write access to the file specified in path.</returns>
-        public static Stream CreateFile(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<Stream> CreateFile(this IFileSystem fileSystem, UPath path)
         {
             path.AssertAbsolute();
             return fileSystem.OpenFile(path, FileMode.Create, FileAccess.ReadWrite);
@@ -568,7 +571,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for directories.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateDirectories(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<UPath>> EnumerateDirectories(this IFileSystem fileSystem, UPath path)
         {
             return EnumerateDirectories(fileSystem, path, "*");
         }
@@ -581,7 +584,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateDirectories(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<UPath>> EnumerateDirectories(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumerateDirectories(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -598,11 +601,10 @@ namespace Zio
         /// or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateDirectories(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
+        public static ValueTask<IEnumerable<UPath>> EnumerateDirectories(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
-            foreach (var subPath in fileSystem.EnumeratePaths(path, searchPattern, searchOption, SearchTarget.Directory))
-                yield return subPath;
+            return fileSystem.EnumeratePaths(path, searchPattern, searchOption, SearchTarget.Directory);
         }
 
         /// <summary>
@@ -611,7 +613,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for files.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateFiles(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<UPath>> EnumerateFiles(this IFileSystem fileSystem, UPath path)
         {
             return EnumerateFiles(fileSystem, path, "*");
         }
@@ -624,7 +626,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateFiles(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<UPath>> EnumerateFiles(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumerateFiles(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -641,11 +643,10 @@ namespace Zio
         /// or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumerateFiles(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
+        public static ValueTask<IEnumerable<UPath>> EnumerateFiles(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
-            foreach (var subPath in fileSystem.EnumeratePaths(path, searchPattern, searchOption, SearchTarget.File))
-                yield return subPath;
+            return fileSystem.EnumeratePaths(path, searchPattern, searchOption, SearchTarget.File);
         }
 
         /// <summary>
@@ -654,7 +655,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for files or directories.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files and directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumeratePaths(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<UPath>> EnumeratePaths(this IFileSystem fileSystem, UPath path)
         {
             return EnumeratePaths(fileSystem, path, "*");
         }
@@ -667,7 +668,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files and directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumeratePaths(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<UPath>> EnumeratePaths(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumeratePaths(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -684,7 +685,7 @@ namespace Zio
         /// or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
         /// <returns>An enumerable collection of the full names (including paths) for the files and directories in the directory specified by path.</returns>
-        public static IEnumerable<UPath> EnumeratePaths(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
+        public static ValueTask<IEnumerable<UPath>> EnumeratePaths(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return fileSystem.EnumeratePaths(path, searchPattern, searchOption, SearchTarget.Both);
@@ -696,7 +697,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for files.</param>
         /// <returns>An enumerable collection of <see cref="FileEntry"/> from the specified path.</returns>
-        public static IEnumerable<FileEntry> EnumerateFileEntries(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<FileEntry>> EnumerateFileEntries(this IFileSystem fileSystem, UPath path)
         {
             return EnumerateFileEntries(fileSystem, path, "*");
         }
@@ -709,7 +710,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of <see cref="FileEntry"/> from the specified path.</returns>
-        public static IEnumerable<FileEntry> EnumerateFileEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<FileEntry>> EnumerateFileEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumerateFileEntries(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -726,13 +727,10 @@ namespace Zio
         /// or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
         /// <returns>An enumerable collection of <see cref="FileEntry"/> from the specified path.</returns>
-        public static IEnumerable<FileEntry> EnumerateFileEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
+        public static async ValueTask<IEnumerable<FileEntry>> EnumerateFileEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
-            foreach (var subPath in EnumerateFiles(fileSystem, path, searchPattern, searchOption))
-            {
-                yield return new FileEntry(fileSystem, subPath);
-            }
+            return (await EnumerateFiles(fileSystem, path, searchPattern, searchOption)).Select(subPath => new FileEntry(fileSystem, subPath)).ToArray();
         }
 
         /// <summary>
@@ -741,7 +739,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for directories.</param>
         /// <returns>An enumerable collection of <see cref="DirectoryEntry"/> from the specified path.</returns>
-        public static IEnumerable<DirectoryEntry> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<DirectoryEntry>> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path)
         {
             return EnumerateDirectoryEntries(fileSystem, path, "*");
         }
@@ -754,7 +752,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of <see cref="DirectoryEntry"/> from the specified path.</returns>
-        public static IEnumerable<DirectoryEntry> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<DirectoryEntry>> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumerateDirectoryEntries(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -771,13 +769,10 @@ namespace Zio
         /// or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
         /// <returns>An enumerable collection of <see cref="DirectoryEntry"/> from the specified path.</returns>
-        public static IEnumerable<DirectoryEntry> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
+        public static async ValueTask<IEnumerable<DirectoryEntry>> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
-            foreach (var subPath in EnumerateDirectories(fileSystem, path, searchPattern, searchOption))
-            {
-                yield return new DirectoryEntry(fileSystem, subPath);
-            }
+            return (await EnumerateDirectories(fileSystem, path, searchPattern, searchOption)).Select(subPath => new DirectoryEntry(fileSystem, subPath)).ToArray();
         }
 
         /// <summary>
@@ -786,7 +781,7 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path of the directory to look for files and directories.</param>
         /// <returns>An enumerable collection of <see cref="FileSystemEntry"/> that match a search pattern in a specified path.</returns>
-        public static IEnumerable<FileSystemEntry> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path)
+        public static ValueTask<IEnumerable<FileSystemEntry>> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path)
         {
             return EnumerateFileSystemEntries(fileSystem, path, "*");
         }
@@ -799,7 +794,7 @@ namespace Zio
         /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
         /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <returns>An enumerable collection of <see cref="FileSystemEntry"/> that match a search pattern in a specified path.</returns>
-        public static IEnumerable<FileSystemEntry> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
+        public static ValueTask<IEnumerable<FileSystemEntry>> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
             return EnumerateFileSystemEntries(fileSystem, path, searchPattern, SearchOption.TopDirectoryOnly);
@@ -817,13 +812,18 @@ namespace Zio
         /// The default value is TopDirectoryOnly.</param>
         /// <param name="searchTarget">The search target either <see cref="SearchTarget.Both"/> or only <see cref="SearchTarget.Directory"/> or <see cref="SearchTarget.File"/>. Default is <see cref="SearchTarget.Both"/></param>
         /// <returns>An enumerable collection of <see cref="FileSystemEntry"/> that match a search pattern in a specified path.</returns>
-        public static IEnumerable<FileSystemEntry> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget = SearchTarget.Both)
+        public static async ValueTask<IEnumerable<FileSystemEntry>> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget = SearchTarget.Both)
         {
             if (searchPattern is null) throw new ArgumentNullException(nameof(searchPattern));
-            foreach (var subPath in fileSystem.EnumeratePaths(path, searchPattern, searchOption, searchTarget))
+            
+            var entries = new List<FileSystemEntry>();
+            
+            foreach (var subPath in await fileSystem.EnumeratePaths(path, searchPattern, searchOption, searchTarget))
             {
-                yield return fileSystem.DirectoryExists(subPath) ? (FileSystemEntry) new DirectoryEntry(fileSystem, subPath) : new FileEntry(fileSystem, subPath);
+                entries.Add(await fileSystem.DirectoryExists(subPath) ? (FileSystemEntry)new DirectoryEntry(fileSystem, subPath) : (FileSystemEntry)new FileEntry(fileSystem, subPath));
             }
+
+            return entries;
         }
 
         /// <summary>
@@ -832,14 +832,14 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The file or directory path.</param>
         /// <returns>A new <see cref="FileSystemEntry"/> from the specified path.</returns>
-        public static FileSystemEntry GetFileSystemEntry(this IFileSystem fileSystem, UPath path)
+        public static async ValueTask<FileSystemEntry> GetFileSystemEntry(this IFileSystem fileSystem, UPath path)
         {
-            var fileExists = fileSystem.FileExists(path);
+            var fileExists = await fileSystem.FileExists(path);
             if (fileExists)
             {
                 return new FileEntry(fileSystem, path);
             }
-            var directoryExists = fileSystem.DirectoryExists(path);
+            var directoryExists = await fileSystem.DirectoryExists(path);
             if (directoryExists)
             {
                 return new DirectoryEntry(fileSystem, path);
@@ -854,14 +854,14 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The file or directory path.</param>
         /// <returns>A new <see cref="FileSystemEntry"/> from the specified path.</returns>
-        public static FileSystemEntry? TryGetFileSystemEntry(this IFileSystem fileSystem, UPath path)
+        public static async ValueTask<FileSystemEntry?> TryGetFileSystemEntry(this IFileSystem fileSystem, UPath path)
         {
-            var fileExists = fileSystem.FileExists(path);
+            var fileExists = await fileSystem.FileExists(path);
             if (fileExists)
             {
                 return new FileEntry(fileSystem, path);
             }
-            var directoryExists = fileSystem.DirectoryExists(path);
+            var directoryExists = await fileSystem.DirectoryExists(path);
             if (directoryExists)
             {
                 return new DirectoryEntry(fileSystem, path);
@@ -876,9 +876,9 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="filePath">The file path.</param>
         /// <returns>A new <see cref="FileEntry"/> from the specified path.</returns>
-        public static FileEntry GetFileEntry(this IFileSystem fileSystem, UPath filePath)
+        public static async ValueTask<FileEntry> GetFileEntry(this IFileSystem fileSystem, UPath filePath)
         {
-            if (!fileSystem.FileExists(filePath))
+            if (!await fileSystem.FileExists(filePath))
             {
                 throw NewFileNotFoundException(filePath);
             }
@@ -891,9 +891,9 @@ namespace Zio
         /// <param name="fileSystem">The file system.</param>
         /// <param name="directoryPath">The directory path.</param>
         /// <returns>A new <see cref="DirectoryEntry"/> from the specified path.</returns>
-        public static DirectoryEntry GetDirectoryEntry(this IFileSystem fileSystem, UPath directoryPath)
+        public static async ValueTask<DirectoryEntry> GetDirectoryEntry(this IFileSystem fileSystem, UPath directoryPath)
         {
-            if (!fileSystem.DirectoryExists(directoryPath))
+            if (!await fileSystem.DirectoryExists(directoryPath))
             {
                 throw NewDirectoryNotFoundException(directoryPath);
             }

--- a/src/Zio/FileSystemItem.cs
+++ b/src/Zio/FileSystemItem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Zio
 {
@@ -116,7 +117,7 @@ namespace Zio
         ///     drive.
         /// </exception>
         /// <exception cref="T:System.IO.IOException">The file is already open. </exception>
-        public readonly Stream Open(FileMode mode, FileAccess access, FileShare share = FileShare.None)
+        public readonly ValueTask<Stream> Open(FileMode mode, FileAccess access, FileShare share = FileShare.None)
         {
             if (FileSystem == null) throw NewThrowNotInitialized();
             return FileSystem.OpenFile(AbsolutePath, mode, access, share);
@@ -126,7 +127,7 @@ namespace Zio
         /// Checks if the file exists.
         /// </summary>
         /// <returns></returns>
-        public readonly bool Exists() => FileSystem != null && (IsDirectory ? FileSystem.DirectoryExists(AbsolutePath) : FileSystem.FileExists(AbsolutePath));
+        public readonly async ValueTask<bool> Exists() => FileSystem != null && (IsDirectory ? await FileSystem.DirectoryExists(AbsolutePath) : await FileSystem.FileExists(AbsolutePath));
 
         /// <summary>
         ///     Opens a file, reads all lines of the file with the specified encoding, and then closes the file.
@@ -136,7 +137,7 @@ namespace Zio
         ///     This method attempts to automatically detect the encoding of a file based on the presence of byte order marks.
         ///     Encoding formats UTF-8 and UTF-32 (both big-endian and little-endian) can be detected.
         /// </remarks>
-        public readonly string ReadAllText()
+        public readonly Task<string> ReadAllText()
         {
             if (FileSystem == null) throw NewThrowNotInitialized();
             return FileSystem.ReadAllText(AbsolutePath);

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Zio.FileSystems
 {
@@ -66,27 +68,27 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override void CreateDirectoryImpl(UPath path)
+        protected override ValueTask CreateDirectoryImpl(UPath path)
         {
-            FallbackSafe.CreateDirectory(ConvertPathToDelegate(path));
+            return FallbackSafe.CreateDirectory(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override bool DirectoryExistsImpl(UPath path)
+        protected override ValueTask<bool> DirectoryExistsImpl(UPath path)
         {
             return FallbackSafe.DirectoryExists(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void MoveDirectoryImpl(UPath srcPath, UPath destPath)
+        protected override ValueTask MoveDirectoryImpl(UPath srcPath, UPath destPath)
         {
-            FallbackSafe.MoveDirectory(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath));
+            return FallbackSafe.MoveDirectory(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath));
         }
 
         /// <inheritdoc />
-        protected override void DeleteDirectoryImpl(UPath path, bool isRecursive)
+        protected override ValueTask DeleteDirectoryImpl(UPath path, bool isRecursive)
         {
-            FallbackSafe.DeleteDirectory(ConvertPathToDelegate(path), isRecursive);
+            return FallbackSafe.DeleteDirectory(ConvertPathToDelegate(path), isRecursive);
         }
 
         // ----------------------------------------------
@@ -94,44 +96,44 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override void CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
+        protected override ValueTask CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
         {
-            FallbackSafe.CopyFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath), overwrite);
+            return FallbackSafe.CopyFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath), overwrite);
         }
 
         /// <inheritdoc />
-        protected override void ReplaceFileImpl(UPath srcPath, UPath destPath, UPath destBackupPath,
+        protected override ValueTask ReplaceFileImpl(UPath srcPath, UPath destPath, UPath destBackupPath,
             bool ignoreMetadataErrors)
         {
-            FallbackSafe.ReplaceFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath), destBackupPath.IsNull ? destBackupPath : ConvertPathToDelegate(destBackupPath), ignoreMetadataErrors);
+            return FallbackSafe.ReplaceFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath), destBackupPath.IsNull ? destBackupPath : ConvertPathToDelegate(destBackupPath), ignoreMetadataErrors);
         }
 
         /// <inheritdoc />
-        protected override long GetFileLengthImpl(UPath path)
+        protected override ValueTask<long> GetFileLengthImpl(UPath path)
         {
             return FallbackSafe.GetFileLength(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override bool FileExistsImpl(UPath path)
+        protected override ValueTask<bool> FileExistsImpl(UPath path)
         {
             return FallbackSafe.FileExists(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void MoveFileImpl(UPath srcPath, UPath destPath)
+        protected override ValueTask MoveFileImpl(UPath srcPath, UPath destPath)
         {
-            FallbackSafe.MoveFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath));
+            return FallbackSafe.MoveFile(ConvertPathToDelegate(srcPath), ConvertPathToDelegate(destPath));
         }
 
         /// <inheritdoc />
-        protected override void DeleteFileImpl(UPath path)
+        protected override ValueTask DeleteFileImpl(UPath path)
         {
-            FallbackSafe.DeleteFile(ConvertPathToDelegate(path));
+            return FallbackSafe.DeleteFile(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override Stream OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None)
+        protected override ValueTask<Stream> OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None)
         {
             return FallbackSafe.OpenFile(ConvertPathToDelegate(path), mode, access, share);
         }
@@ -141,51 +143,51 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override FileAttributes GetAttributesImpl(UPath path)
+        protected override ValueTask<FileAttributes> GetAttributesImpl(UPath path)
         {
             return FallbackSafe.GetAttributes(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void SetAttributesImpl(UPath path, FileAttributes attributes)
+        protected override ValueTask SetAttributesImpl(UPath path, FileAttributes attributes)
         {
-            FallbackSafe.SetAttributes(ConvertPathToDelegate(path), attributes);
+            return FallbackSafe.SetAttributes(ConvertPathToDelegate(path), attributes);
         }
 
         /// <inheritdoc />
-        protected override DateTime GetCreationTimeImpl(UPath path)
+        protected override ValueTask<DateTime> GetCreationTimeImpl(UPath path)
         {
             return FallbackSafe.GetCreationTime(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void SetCreationTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetCreationTimeImpl(UPath path, DateTime time)
         {
-            FallbackSafe.SetCreationTime(ConvertPathToDelegate(path), time);
+            return FallbackSafe.SetCreationTime(ConvertPathToDelegate(path), time);
         }
 
         /// <inheritdoc />
-        protected override DateTime GetLastAccessTimeImpl(UPath path)
+        protected override ValueTask<DateTime> GetLastAccessTimeImpl(UPath path)
         {
             return FallbackSafe.GetLastAccessTime(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void SetLastAccessTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetLastAccessTimeImpl(UPath path, DateTime time)
         {
-            FallbackSafe.SetLastAccessTime(ConvertPathToDelegate(path), time);
+            return FallbackSafe.SetLastAccessTime(ConvertPathToDelegate(path), time);
         }
 
         /// <inheritdoc />
-        protected override DateTime GetLastWriteTimeImpl(UPath path)
+        protected override ValueTask<DateTime> GetLastWriteTimeImpl(UPath path)
         {
             return FallbackSafe.GetLastWriteTime(ConvertPathToDelegate(path));
         }
 
         /// <inheritdoc />
-        protected override void SetLastWriteTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetLastWriteTimeImpl(UPath path, DateTime time)
         {
-            FallbackSafe.SetLastWriteTime(ConvertPathToDelegate(path), time);
+            return FallbackSafe.SetLastWriteTime(ConvertPathToDelegate(path), time);
         }
 
         // ----------------------------------------------
@@ -193,23 +195,22 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
+        protected override async ValueTask<IEnumerable<UPath>> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
         {
-            foreach (var subPath in FallbackSafe.EnumeratePaths(ConvertPathToDelegate(path), searchPattern, searchOption, searchTarget))
-            {
-                yield return ConvertPathFromDelegate(subPath);
-            }
+            var paths = await FallbackSafe.EnumeratePaths(ConvertPathToDelegate(path), searchPattern, searchOption, searchTarget);
+            return paths.Select(ConvertPathFromDelegate).ToArray();
         }
 
         /// <inheritdoc />
-        protected override IEnumerable<FileSystemItem> EnumerateItemsImpl(UPath path, SearchOption searchOption, SearchPredicate? searchPredicate)
+        protected override async ValueTask<IEnumerable<FileSystemItem>> EnumerateItemsImpl(UPath path, SearchOption searchOption, SearchPredicate? searchPredicate)
         {
-            foreach (var subItem in FallbackSafe.EnumerateItems(ConvertPathToDelegate(path), searchOption, searchPredicate))
+            var items = await FallbackSafe.EnumerateItems(ConvertPathToDelegate(path), searchOption, searchPredicate);
+            return items.Select(subItem =>
             {
                 var localItem = subItem;
                 localItem.Path = ConvertPathFromDelegate(localItem.Path);
-                yield return localItem;
-            }
+                return localItem;
+            }).ToArray();
         }
 
         // ----------------------------------------------

--- a/src/Zio/FileSystems/ReadOnlyFileSystem.cs
+++ b/src/Zio/FileSystems/ReadOnlyFileSystem.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Zio.FileSystems
 {
@@ -34,19 +35,19 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override void CreateDirectoryImpl(UPath path)
+        protected override ValueTask CreateDirectoryImpl(UPath path)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void MoveDirectoryImpl(UPath srcPath, UPath destPath)
+        protected override ValueTask MoveDirectoryImpl(UPath srcPath, UPath destPath)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void DeleteDirectoryImpl(UPath path, bool isRecursive)
+        protected override ValueTask DeleteDirectoryImpl(UPath path, bool isRecursive)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
@@ -56,31 +57,31 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override void CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
+        protected override ValueTask CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void ReplaceFileImpl(UPath srcPath, UPath destPath, UPath destBackupPath, bool ignoreMetadataErrors)
+        protected override ValueTask ReplaceFileImpl(UPath srcPath, UPath destPath, UPath destBackupPath, bool ignoreMetadataErrors)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void MoveFileImpl(UPath srcPath, UPath destPath)
+        protected override ValueTask MoveFileImpl(UPath srcPath, UPath destPath)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void DeleteFileImpl(UPath path)
+        protected override ValueTask DeleteFileImpl(UPath path)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override Stream OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None)
+        protected override ValueTask<Stream> OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None)
         {
             if (mode != FileMode.Open)
             {
@@ -100,32 +101,32 @@ namespace Zio.FileSystems
         // ----------------------------------------------
 
         /// <inheritdoc />
-        protected override FileAttributes GetAttributesImpl(UPath path)
+        protected override async ValueTask<FileAttributes> GetAttributesImpl(UPath path)
         {
             // All paths are readonly
-            return base.GetAttributesImpl(path) | FileAttributes.ReadOnly;
+            return await base.GetAttributesImpl(path) | FileAttributes.ReadOnly;
         }
 
         /// <inheritdoc />
-        protected override void SetAttributesImpl(UPath path, FileAttributes attributes)
+        protected override ValueTask SetAttributesImpl(UPath path, FileAttributes attributes)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void SetCreationTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetCreationTimeImpl(UPath path, DateTime time)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void SetLastAccessTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetLastAccessTimeImpl(UPath path, DateTime time)
         {
             throw new IOException(FileSystemIsReadOnly);
         }
 
         /// <inheritdoc />
-        protected override void SetLastWriteTimeImpl(UPath path, DateTime time)
+        protected override ValueTask SetLastWriteTimeImpl(UPath path, DateTime time)
         {
             throw new IOException(FileSystemIsReadOnly);
         }

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Zio
 {
@@ -21,28 +22,28 @@ namespace Zio
         /// Creates all directories and subdirectories in the specified path unless they already exist.
         /// </summary>
         /// <param name="path">The directory to create.</param>
-        void CreateDirectory(UPath path);
+        ValueTask CreateDirectory(UPath path);
 
         /// <summary>
         /// Determines whether the given path refers to an existing directory on disk.
         /// </summary>
         /// <param name="path">The path to test.</param>
         /// <returns><c>true</c> if the given path refers to an existing directory on disk, <c>false</c> otherwise.</returns>
-        bool DirectoryExists(UPath path);
+        ValueTask<bool> DirectoryExists(UPath path);
 
         /// <summary>
         /// Moves a directory and its contents to a new location.
         /// </summary>
         /// <param name="srcPath">The path of the directory to move.</param>
         /// <param name="destPath">The path to the new location for <paramref name="srcPath"/></param>
-        void MoveDirectory(UPath srcPath, UPath destPath);
+        ValueTask MoveDirectory(UPath srcPath, UPath destPath);
 
         /// <summary>
         /// Deletes the specified directory and, if indicated, any subdirectories and files in the directory. 
         /// </summary>
         /// <param name="path">The path of the directory to remove.</param>
         /// <param name="isRecursive"><c>true</c> to remove directories, subdirectories, and files in path; otherwise, <c>false</c>.</param>
-        void DeleteDirectory(UPath path, bool isRecursive);
+        ValueTask DeleteDirectory(UPath path, bool isRecursive);
 
         // ----------------------------------------------
         // File API
@@ -54,7 +55,7 @@ namespace Zio
         /// <param name="srcPath">The path of the file to copy.</param>
         /// <param name="destPath">The path of the destination file. This cannot be a directory.</param>
         /// <param name="overwrite"><c>true</c> if the destination file can be overwritten; otherwise, <c>false</c>.</param>
-        void CopyFile(UPath srcPath, UPath destPath, bool overwrite);
+        ValueTask CopyFile(UPath srcPath, UPath destPath, bool overwrite);
 
         /// <summary>
         /// Replaces the contents of a specified file with the contents of another file, deleting the original file, and creating a backup of the replaced file and optionally ignores merge errors.
@@ -63,14 +64,14 @@ namespace Zio
         /// <param name="destPath">The path of the file being replaced.</param>
         /// <param name="destBackupPath">The path of the backup file (maybe null, in that case, it doesn't create any backup)</param>
         /// <param name="ignoreMetadataErrors"><c>true</c> to ignore merge errors (such as attributes and access control lists (ACLs)) from the replaced file to the replacement file; otherwise, <c>false</c>.</param>
-        void ReplaceFile(UPath srcPath, UPath destPath, UPath destBackupPath, bool ignoreMetadataErrors);
+        ValueTask ReplaceFile(UPath srcPath, UPath destPath, UPath destBackupPath, bool ignoreMetadataErrors);
 
         /// <summary>
         /// Gets the size, in bytes, of a file.
         /// </summary>
         /// <param name="path">The path of a file.</param>
         /// <returns>The size, in bytes, of the file</returns>
-        long GetFileLength(UPath path);
+        ValueTask<long> GetFileLength(UPath path);
 
         /// <summary>
         /// Determines whether the specified file exists.
@@ -80,20 +81,20 @@ namespace Zio
         /// otherwise, <c>false</c>. This method also returns false if path is null, an invalid path, or a zero-length string. 
         /// If the caller does not have sufficient permissions to read the specified file, 
         /// no exception is thrown and the method returns false regardless of the existence of path.</returns>
-        bool FileExists(UPath path);
+        ValueTask<bool> FileExists(UPath path);
 
         /// <summary>
         /// Moves a specified file to a new location, providing the option to specify a new file name.
         /// </summary>
         /// <param name="srcPath">The path of the file to move.</param>
         /// <param name="destPath">The new path and name for the file.</param>
-        void MoveFile(UPath srcPath, UPath destPath);
+        ValueTask MoveFile(UPath srcPath, UPath destPath);
 
         /// <summary>
         /// Deletes the specified file. 
         /// </summary>
         /// <param name="path">The path of the file to be deleted.</param>
-        void DeleteFile(UPath path);
+        ValueTask DeleteFile(UPath path);
 
         /// <summary>
         /// Opens a file <see cref="Stream"/> on the specified path, having the specified mode with read, write, or read/write access and the specified sharing option.
@@ -103,7 +104,7 @@ namespace Zio
         /// <param name="access">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
         /// <param name="share">A <see cref="FileShare"/> value specifying the type of access other threads have to the file.</param>
         /// <returns>A file <see cref="Stream"/> on the specified path, having the specified mode with read, write, or read/write access and the specified sharing option.</returns>
-        Stream OpenFile(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None);
+        ValueTask<Stream> OpenFile(UPath path, FileMode mode, FileAccess access, FileShare share = FileShare.None);
 
         // ----------------------------------------------
         // Metadata API
@@ -114,56 +115,56 @@ namespace Zio
         /// </summary>
         /// <param name="path">The path to the file or directory.</param>
         /// <returns>The <see cref="FileAttributes"/> of the file or directory on the path.</returns>
-        FileAttributes GetAttributes(UPath path);
+        ValueTask<FileAttributes> GetAttributes(UPath path);
 
         /// <summary>
         /// Sets the specified <see cref="FileAttributes"/> of the file or directory on the specified path.
         /// </summary>
         /// <param name="path">The path to the file or directory.</param>
         /// <param name="attributes">A bitwise combination of the enumeration values.</param>
-        void SetAttributes(UPath path, FileAttributes attributes);
+        ValueTask SetAttributes(UPath path, FileAttributes attributes);
 
         /// <summary>
         /// Returns the creation date and time of the specified file or directory.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to obtain creation date and time information.</param>
         /// <returns>A <see cref="DateTime"/> structure set to the creation date and time for the specified file or directory. This value is expressed in local time.</returns>
-        DateTime GetCreationTime(UPath path);
+        ValueTask<DateTime> GetCreationTime(UPath path);
 
         /// <summary>
         /// Sets the date and time the file was created.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to set the creation date and time.</param>
         /// <param name="time">A <see cref="DateTime"/> containing the value to set for the creation date and time of path. This value is expressed in local time.</param>
-        void SetCreationTime(UPath path, DateTime time);
+        ValueTask SetCreationTime(UPath path, DateTime time);
 
         /// <summary>
         /// Returns the last access date and time of the specified file or directory.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to obtain creation date and time information.</param>
         /// <returns>A <see cref="DateTime"/> structure set to the last access date and time for the specified file or directory. This value is expressed in local time.</returns>
-        DateTime GetLastAccessTime(UPath path);
+        ValueTask<DateTime> GetLastAccessTime(UPath path);
 
         /// <summary>
         /// Sets the date and time the file was last accessed.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to set the last access date and time.</param>
         /// <param name="time">A <see cref="DateTime"/> containing the value to set for the last access date and time of path. This value is expressed in local time.</param>
-        void SetLastAccessTime(UPath path, DateTime time);
+        ValueTask SetLastAccessTime(UPath path, DateTime time);
 
         /// <summary>
         /// Returns the last write date and time of the specified file or directory.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to obtain creation date and time information.</param>
         /// <returns>A <see cref="DateTime"/> structure set to the last write date and time for the specified file or directory. This value is expressed in local time.</returns>
-        DateTime GetLastWriteTime(UPath path);
+        ValueTask<DateTime> GetLastWriteTime(UPath path);
 
         /// <summary>
         /// Sets the date and time that the specified file was last written to.
         /// </summary>
         /// <param name="path">The path to a file or directory for which to set the last write date and time.</param>
         /// <param name="time">A <see cref="DateTime"/> containing the value to set for the last write date and time of path. This value is expressed in local time.</param>
-        void SetLastWriteTime(UPath path, DateTime time);
+        ValueTask SetLastWriteTime(UPath path, DateTime time);
 
         // ----------------------------------------------
         // Search API
@@ -177,7 +178,7 @@ namespace Zio
         /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory or should include all subdirectories.</param>
         /// <param name="searchTarget">The search target either <see cref="SearchTarget.Both"/> or only <see cref="SearchTarget.Directory"/> or <see cref="SearchTarget.File"/>.</param>
         /// <returns>An enumerable collection of file-system paths in the directory specified by path and that match the specified search pattern, option and target.</returns>
-        IEnumerable<UPath> EnumeratePaths(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget);
+        ValueTask<IEnumerable<UPath>> EnumeratePaths(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget);
 
         /// <summary>
         /// Returns an enumerable collection of <see cref="FileSystemItem"/> that match a search pattern in a specified path, and optionally searches subdirectories.
@@ -186,7 +187,7 @@ namespace Zio
         /// <param name="searchPredicate">The search string to match against file-system entries in path. This parameter can contain a combination of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
         /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory or should include all subdirectories.</param>
         /// <returns>An enumerable collection of <see cref="FileSystemItem"/> in the directory specified by path and that match the specified search pattern, option and target.</returns>
-        IEnumerable<FileSystemItem> EnumerateItems(UPath path, SearchOption searchOption, SearchPredicate? searchPredicate = null);
+        ValueTask<IEnumerable<FileSystemItem>> EnumerateItems(UPath path, SearchOption searchOption, SearchPredicate? searchPredicate = null);
 
         // ----------------------------------------------
         // Watch API

--- a/src/Zio/UPath.cs
+++ b/src/Zio/UPath.cs
@@ -214,7 +214,7 @@ namespace Zio
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is UPath path && Equals(path);
         }

--- a/src/Zio/Zio.csproj
+++ b/src/Zio/Zio.csproj
@@ -6,7 +6,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.13.0</VersionPrefix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net40;net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <AssemblyName>Zio</AssemblyName>
     <PackageId>Zio</PackageId>
     <PackageTags>filesystem;vfs;VirtualFileSystem;virtual;abstract;directory;files;io;mock</PackageTags>
@@ -29,8 +29,13 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
     <Reference Include="System.IO.Compression" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE</DefineConstants>
   </PropertyGroup>
@@ -42,7 +47,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE;HAS_NULLABLEANNOTATIONS</DefineConstants>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE;HAS_NULLABLEANNOTATIONS;NET60</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
     <DefineConstants>$(AdditionalConstants);NET45;HAS_ZIPARCHIVE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/xoofx/zio/issues/53

I gave it a try to convert anything that would require async. I didn't go with duplicating methods.
All tests pass, if not run concurrently ;) there must be some wrong locking of maybe I missed an await and some race condition happens. Running groups of them work fine.

Hopefully it gives an idea of the required changes, and the usage. Would be a major version bump, losing .NET 4.0 target too. I decided to not use the 'Async' suffix has it made less work, but I would suggest to add it.

I hope someone will try and improve it to fix the concurrency issues, but I won't be offended if you close the PR, I don't think I will put up much time on it, though didn't want to go to waste either.

