### PR TITLE
add ZipArchive support

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -234,6 +234,8 @@ The default filesystems provided by Zio comes roughly into two kinds:
 
   - `MemoryFileSystem` operating in-memory
 
+  - `ZipArchiveFileSystem` operating on a zip file
+
 - **Composite file systems** : These are used to built higher level filesystems by composing them with Concrete and Composite filesystems
 
   - `AggregateFileSystem` providing a merged view read-only filesystem over multiple filesystems
@@ -305,6 +307,27 @@ This unique internal design allow this filesystem to provide:
 In addition to a much faster filesystem in memory compare to a `PhysicalFileSystem`, the method `MemoryFileSystem.Clone()` provides also a useful utility method to efficiently clone the entire filesystem.
 
 **This filesystem can be used for mocking scenarios** while keeping the behavior of a real filesystem.
+
+#### `ZipArchiveFileSystem`
+
+This filesystem provides an implementation of `IFileSystem` while performing all operations on a zip archive.
+
+```C#
+var fs = new ZipArchiveFileSystem("C://Test.zip");
+
+fs.DirectoryCreate("test")
+```
+
+It uses ZipArchive class for manipulating file entries.
+
+**There are some limitations** of this filesystem resulting from limitations of ZipArchive:
+
+- This file system is only avaliable on .NET 4.5 and newer.
+- Entry creation time and last access time are not supported. Trying to get them will return last write time and trying to set them will do nothing.
+- File attributes are only supported by .NET Standard 2.1. Trying to get attributes in lower versions will return Normal, Archive or Directory. Trying to set them will do nothing.
+- FileShare is only supported in ZipArchive read mode. Trying to open multiple streams in write and update mode throws an exception.
+
+This filesystem has case sensitive and case insensitive modes.
 
 ### Composite FileSystem
 

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,10 @@ Zio provides a simple, powerful, cross-platform **filesystem abstraction for .NE
     - A safe hierarchical locking strategy (following [Unix kernel recommendations for directory locking](https://www.kernel.org/doc/Documentation/filesystems/directory-locking))
     - Support for `FileShare.Read`, `FileShare.Write` and `FileShare.ReadWrite`
     - Internally support for filesystem atomic operations (`File.Replace`)
+  - `ZipArchiveFileSystem` to access zip archives:
+    - This filesystem is a wrapper around the [`ZipArchive`](https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.ziparchive?view=netcore-3.1) class
+	- It can work in case sensitive and case insensitive mode
+	- Support for `FileShare.Read` with `ZipArchiveMode.Read`
   - On top of these final filesystem, you can compose more complex filesystems:
     - `AggregateFileSystem` providing a read-only filesystem aggregating multiple filesystem that offers a merged view
     - `MountFileSystem` to mount different filesystems at a specific mount point name
@@ -68,7 +72,6 @@ In order to build Zio, you need to install Visual Studio 2017 with latest [.NET 
 
 ## TODO
 
-- [ ] Add support for ZipArchive (readonly, readwrite)
 - [ ] Add support for Git FileSystem (readonly)
 
 ## License

--- a/src/Zio.Tests/FileSystems/TestFileSystemBase.cs
+++ b/src/Zio.Tests/FileSystems/TestFileSystemBase.cs
@@ -11,6 +11,8 @@ using Zio.FileSystems;
 
 namespace Zio.Tests.FileSystems
 {
+    using System.IO.Compression;
+
     public abstract class TestFileSystemBase : IDisposable
     {
         private static readonly UPath[] Directories = new UPath[] { "a", "b", "C", "d" };
@@ -177,6 +179,14 @@ namespace Zio.Tests.FileSystems
             aggfs.AddFileSystem(fs3);
 
             return aggfs;
+        }
+
+        protected ZipArchiveFileSystem GetCommonZipArchiveFileSystem()
+        {
+            var archive = new ZipArchive(new MemoryStream(), ZipArchiveMode.Update);
+            var fs = new ZipArchiveFileSystem(archive);
+            CreateFolderStructure(fs);
+            return fs;
         }
 
         protected MountFileSystem GetCommonMountFileSystemWithOnlyBackup()

--- a/src/Zio.Tests/FileSystems/TestZipArchiveFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestZipArchiveFileSystem.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Xunit;
+using Zio.FileSystems;
+
+namespace Zio.Tests.FileSystems
+{
+
+    public class TestZipArchiveFileSystem : TestFileSystemBase
+    {
+        [Fact]
+        public void TestCommonRead()
+        {
+            var fs = this.GetCommonZipArchiveFileSystem();
+            this.AssertCommonRead(fs);
+        }
+
+        [Fact]
+        public void TestCopyFileSystem()
+        {
+            var fs = this.GetCommonZipArchiveFileSystem();
+
+            var dest = new ZipArchiveFileSystem(new MemoryStream());
+            fs.CopyTo(dest, UPath.Root, true);
+
+            this.AssertFileSystemEqual(fs, dest);
+        }
+        
+        [Fact]
+        public void TestCopyFileSystemSubFolder()
+        {
+            var fs = GetCommonZipArchiveFileSystem();
+
+            var dest = new ZipArchiveFileSystem(new MemoryStream());
+            var subFolder = UPath.Root / "subfolder";
+            fs.CopyTo(dest, subFolder, true);
+
+            var destSubFileSystem = dest.GetOrCreateSubFileSystem(subFolder);
+
+            AssertFileSystemEqual(fs, destSubFileSystem);
+        }
+        
+        [Fact]
+        public void TestWatcher()
+        {
+            var fs = this.GetCommonZipArchiveFileSystem();
+            var watcher = fs.Watch("/a");
+
+            var gotChange = false;
+            watcher.Created += (sender, args) =>
+                {
+                    if (args.FullPath == "/a/watched.txt")
+                    {
+                        gotChange = true;
+                    }
+                };
+
+            watcher.IncludeSubdirectories = true;
+            watcher.EnableRaisingEvents = true;
+
+            fs.WriteAllText("/a/watched.txt", "test");
+            Thread.Sleep(100);
+            Assert.True(gotChange);
+        }
+        
+        [Fact]
+        public void TestFileEntry()
+        {
+            var fs = GetCommonZipArchiveFileSystem();
+
+            var file = new FileEntry(fs, "/a/a/a1.txt");
+            var file2 = new FileEntry(fs, "/a/b.txt");
+
+            Assert.Equal("/a/a/a1.txt", file.ToString());
+
+            Assert.Equal("/a/a/a1.txt", file.FullName);
+            Assert.Equal("a1.txt", file.Name);
+
+            Assert.Equal("b", file2.NameWithoutExtension);
+            Assert.Equal(".txt", file2.ExtensionWithDot);
+
+            Assert.True(file.Length > 0);
+            Assert.False(file.IsReadOnly);
+
+            var dir = file.Directory;
+            Assert.NotNull(dir);
+            Assert.Equal("/a/a", dir.FullName);
+
+            Assert.Null(new DirectoryEntry(fs, "/").Parent);
+
+            var yoyo = new FileEntry(fs, "/a/yoyo.txt");
+            using (var file1 = yoyo.Create())
+            {
+                file1.WriteByte(1);
+                file1.WriteByte(2);
+                file1.WriteByte(3);
+            }
+
+            Assert.Equal(new byte[] { 1, 2, 3 }, fs.ReadAllBytes("/a/yoyo.txt"));
+
+            Assert.Throws<FileNotFoundException>(() => fs.GetFileSystemEntry("/wow.txt"));
+
+            var file3 = fs.GetFileEntry("/a/b.txt");
+            Assert.True(file3.Exists);
+
+            Assert.Null(fs.TryGetFileSystemEntry("/invalid_file"));
+            Assert.IsType<FileEntry>(fs.TryGetFileSystemEntry("/a/b.txt"));
+            Assert.IsType<DirectoryEntry>(fs.TryGetFileSystemEntry("/a"));
+
+            Assert.Throws<FileNotFoundException>(() => fs.GetFileEntry("/invalid"));
+            Assert.Throws<DirectoryNotFoundException>(() => fs.GetDirectoryEntry("/invalid"));
+
+
+            var mydir = new DirectoryEntry(fs, "/yoyo");
+
+            Assert.Throws<ArgumentException>(() => mydir.CreateSubdirectory("/sub"));
+
+            var subFolder = mydir.CreateSubdirectory("sub");
+            Assert.True(subFolder.Exists);
+
+            Assert.Empty(mydir.EnumerateFiles());
+
+            var subDirs = mydir.EnumerateDirectories();
+            Assert.Single(subDirs);
+            Assert.Equal("/yoyo/sub", subDirs.First().FullName);
+
+            mydir.Delete();
+
+            Assert.False(mydir.Exists);
+            Assert.False(subFolder.Exists);
+
+            // Test ReadAllText/WriteAllText/AppendAllText/ReadAllBytes/WriteAllBytes
+            Assert.True(file.ReadAllText().Length > 0);
+            Assert.True(file.ReadAllText(Encoding.UTF8).Length > 0);
+            file.WriteAllText("abc");
+            Assert.Equal("abc", file.ReadAllText());
+            file.WriteAllText("abc", Encoding.UTF8);
+            Assert.Equal("abc", file.ReadAllText(Encoding.UTF8));
+
+            file.AppendAllText("def");
+            Assert.Equal("abcdef", file.ReadAllText());
+            file.AppendAllText("ghi", Encoding.UTF8);
+            Assert.Equal("abcdefghi", file.ReadAllText());
+
+            var lines = file.ReadAllLines();
+            Assert.Single(lines);
+            Assert.Equal("abcdefghi", lines[0]);
+
+            lines = file.ReadAllLines(Encoding.UTF8);
+            Assert.Single(lines);
+            Assert.Equal("abcdefghi", lines[0]);
+
+            Assert.Equal(new byte[] { 1, 2, 3 }, yoyo.ReadAllBytes());
+            yoyo.WriteAllBytes(new byte[] { 1, 2, 3, 4 });
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, yoyo.ReadAllBytes());
+        }
+
+        [Fact]
+        public void TestGetParentDirectory()
+        {
+            var fs = new ZipArchiveFileSystem();
+            var fileEntry = new FileEntry(fs, "/test/tata/titi.txt");
+            // Shoud not throw an error
+            var directory = fileEntry.Directory;
+            Assert.False(directory.Exists);
+            Assert.Equal(UPath.Root / "test/tata", directory.Path);
+        }
+
+        [Fact]
+        public void TestReplaceFile()
+        {
+            var fs = GetCommonZipArchiveFileSystem();
+
+            var file = new FileEntry(fs, "/a/b.txt");
+            file.WriteAllText("abc");
+            Assert.Equal("abc", file.ReadAllText());
+            var file2 = new FileEntry(fs, "/a/copy.txt");
+            file2.WriteAllText("def");
+            Assert.Equal("def", file2.ReadAllText());
+
+            fs.ReplaceFile(file.Path, new UPath("/a/copy.txt"), new UPath("/b/backup.txt"), true);
+            Assert.False(file.Exists);
+
+            var copy = fs.GetFileEntry("/a/copy.txt");
+            Assert.True(copy.Exists);
+            Assert.Equal("abc", copy.ReadAllText());
+            Assert.Equal("def", fs.GetFileEntry("/b/backup.txt").ReadAllText());
+        }
+    }
+}

--- a/src/Zio.Tests/FileSystems/TestZipArchiveFileSystemCompact.cs
+++ b/src/Zio.Tests/FileSystems/TestZipArchiveFileSystemCompact.cs
@@ -1,0 +1,756 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Xunit;
+using Zio.FileSystems;
+
+namespace Zio.Tests.FileSystems
+{
+    public class TestZipArchiveFileSystemCompact
+    {
+        public TestZipArchiveFileSystemCompact()
+        {
+            fs = new ZipArchiveFileSystem();
+        }
+        public IFileSystem fs;
+
+        [Fact]
+        public void TestDirectory()
+        {
+            Assert.True(fs.DirectoryExists("/"));
+            Assert.False(fs.DirectoryExists(null));
+
+            // Test CreateDirectory
+            fs.CreateDirectory("/test");
+            Assert.True(fs.DirectoryExists("/test"));
+            Assert.False(fs.DirectoryExists("/test2"));
+
+            // Test CreateDirectory (sub folders)
+            fs.CreateDirectory("/test/test1/test2/test3");
+            Assert.True(fs.DirectoryExists("/test/test1/test2/test3"));
+            Assert.True(fs.DirectoryExists("/test/test1/test2"));
+            Assert.True(fs.DirectoryExists("/test/test1"));
+            Assert.True(fs.DirectoryExists("/test"));
+
+            // Test DeleteDirectory
+            fs.DeleteDirectory("/test/test1/test2/test3", false);
+            Assert.False(fs.DirectoryExists("/test/test1/test2/test3"));
+            Assert.True(fs.DirectoryExists("/test/test1/test2"));
+            Assert.True(fs.DirectoryExists("/test/test1"));
+            Assert.True(fs.DirectoryExists("/test"));
+
+            // Test MoveDirectory
+            fs.MoveDirectory("/test", "/test2");
+            Assert.True(fs.DirectoryExists("/test2/test1/test2"));
+            Assert.True(fs.DirectoryExists("/test2/test1"));
+            Assert.True(fs.DirectoryExists("/test2"));
+
+            // Test MoveDirectory to sub directory
+            fs.CreateDirectory("/testsub");
+            Assert.True(fs.DirectoryExists("/testsub"));
+            fs.MoveDirectory("/test2", "/testsub/testx");
+            Assert.False(fs.DirectoryExists("/test2"));
+            Assert.True(fs.DirectoryExists("/testsub/testx/test1/test2"));
+            Assert.True(fs.DirectoryExists("/testsub/testx/test1"));
+            Assert.True(fs.DirectoryExists("/testsub/testx"));
+
+            // Test DeleteDirectory - recursive
+            fs.DeleteDirectory("/testsub", true);
+            Assert.False(fs.DirectoryExists("/testsub/testx/test1/test2"));
+            Assert.False(fs.DirectoryExists("/testsub/testx/test1"));
+            Assert.False(fs.DirectoryExists("/testsub/testx"));
+            Assert.False(fs.DirectoryExists("/testsub"));
+        }
+
+        [Fact]
+        public void TestDirectoryExceptions()
+        {
+            Assert.Throws<DirectoryNotFoundException>(() => fs.DeleteDirectory("/dir", true));
+
+            Assert.Throws<DirectoryNotFoundException>(() => fs.MoveDirectory("/dir1", "/dir2"));
+
+            fs.CreateDirectory("/dir1");
+            Assert.Throws<IOException>(() => fs.DeleteFile("/dir1"));
+            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir1", "/dir1"));
+
+            fs.WriteAllText("/toto.txt", "test");
+            Assert.Throws<IOException>(() => fs.CreateDirectory("/toto.txt"));
+            Assert.Throws<IOException>(() => fs.DeleteDirectory("/toto.txt", true));
+            Assert.Throws<IOException>(() => fs.MoveDirectory("/toto.txt", "/test"));
+
+            fs.CreateDirectory("/dir2");
+            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir1", "/dir2"));
+
+#if !NET472
+            fs.SetAttributes("/dir1", FileAttributes.Directory | FileAttributes.ReadOnly);
+            Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir1", true));
+#endif
+        }
+
+        [Fact]
+        public void TestFile()
+        {
+            // Test CreateFile/OpenFile
+            var stream = fs.CreateFile("/toto.txt");
+            var writer = new StreamWriter(stream);
+            var originalContent = "This is the content";
+            writer.Write(originalContent);
+            writer.Flush();
+            stream.Dispose();
+
+            // Test FileExists
+            Assert.False(fs.FileExists(null));
+            Assert.False(fs.FileExists("/titi.txt"));
+            Assert.True(fs.FileExists("/toto.txt"));
+
+            // ReadAllText
+            var content = fs.ReadAllText("/toto.txt");
+            Assert.Equal(originalContent, content);
+
+            // sleep for creation time comparison
+            Thread.Sleep(16);
+
+            // Test CopyFile
+            fs.CopyFile("/toto.txt", "/titi.txt", true);
+            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.True(fs.FileExists("/titi.txt"));
+            content = fs.ReadAllText("/titi.txt");
+            Assert.Equal(originalContent, content);
+
+            // Test Attributes/Times
+            Assert.True(fs.GetFileLength("/toto.txt") > 0);
+            Assert.Equal(fs.GetFileLength("/toto.txt"), fs.GetFileLength("/titi.txt"));
+            Assert.Equal(fs.GetAttributes("/toto.txt"), fs.GetAttributes("/titi.txt"));
+            Assert.NotEqual(fs.GetCreationTime("/toto.txt"), fs.GetCreationTime("/titi.txt"));
+            // Because we read titi.txt just before, access time must be different
+            // Following test is disabled as it seems unstable with NTFS?
+            // Assert.NotEqual(fs.GetLastAccessTime("/toto.txt"), fs.GetLastAccessTime("/titi.txt"));
+
+            Assert.Equal(fs.GetLastWriteTime("/toto.txt").DayOfYear, fs.GetLastWriteTime("/titi.txt").DayOfYear);
+            Assert.Equal(fs.GetLastWriteTime("/toto.txt").Hour, fs.GetLastWriteTime("/titi.txt").Hour);
+
+            var now = DateTime.Now + TimeSpan.FromSeconds(10);
+            //var now1 = DateTime.Now + TimeSpan.FromSeconds(11);
+            //var now2 = DateTime.Now + TimeSpan.FromSeconds(12);
+            // access and creation times are not supported by the zip standard
+            fs.SetCreationTime("/toto.txt", now);
+            //fs.SetLastAccessTime("/toto.txt", now1);
+            //fs.SetLastWriteTime("/toto.txt", now2);
+            //Assert.Equal(now, fs.GetCreationTime("/toto.txt"));
+            //Assert.Equal(now1, fs.GetLastAccessTime("/toto.txt"));
+            //Assert.Equal(now2, fs.GetLastWriteTime("/toto.txt"));
+
+            //Assert.NotEqual(fs.GetCreationTime("/toto.txt"), fs.GetCreationTime("/titi.txt"));
+            //Assert.NotEqual(fs.GetLastAccessTime("/toto.txt"), fs.GetLastAccessTime("/titi.txt"));
+            //Assert.NotEqual(fs.GetLastWriteTime("/toto.txt"), fs.GetLastWriteTime("/titi.txt"));
+
+            // Test MoveFile
+            fs.MoveFile("/toto.txt", "/tata.txt");
+            Assert.False(fs.FileExists("/toto.txt"));
+            Assert.True(fs.FileExists("/tata.txt"));
+            Assert.True(fs.FileExists("/titi.txt"));
+            content = fs.ReadAllText("/tata.txt");
+            Assert.Equal(originalContent, content);
+
+            // Test Enumerate file
+            var files = fs.EnumerateFiles("/").Select(p => p.FullName).ToList();
+            files.Sort();
+            Assert.Equal(new List<string>() { "/tata.txt", "/titi.txt" }, files);
+
+            var dirs = fs.EnumerateDirectories("/").Select(p => p.FullName).ToList();
+            Assert.Empty(dirs);
+
+            // Check ReplaceFile
+            var originalContent2 = "this is a content2";
+            fs.WriteAllText("/tata.txt", originalContent2);
+            fs.ReplaceFile("/tata.txt", "/titi.txt", "/titi.bak.txt", true);
+            Assert.False(fs.FileExists("/tata.txt"));
+            Assert.True(fs.FileExists("/titi.txt"));
+            Assert.True(fs.FileExists("/titi.bak.txt"));
+            content = fs.ReadAllText("/titi.txt");
+            Assert.Equal(originalContent2, content);
+            content = fs.ReadAllText("/titi.bak.txt");
+            Assert.Equal(originalContent, content);
+
+            // Check File ReadOnly
+#if !NET472
+            fs.SetAttributes("/titi.txt", FileAttributes.ReadOnly);
+            Assert.Throws<UnauthorizedAccessException>(() => fs.DeleteFile("/titi.txt"));
+            Assert.Throws<UnauthorizedAccessException>(() => fs.CopyFile("/titi.bak.txt", "/titi.txt", true));
+            Assert.Throws<UnauthorizedAccessException>(() => fs.OpenFile("/titi.txt", FileMode.Open, FileAccess.ReadWrite));
+            fs.SetAttributes("/titi.txt", FileAttributes.Normal);
+#endif
+            // Delete File
+            fs.DeleteFile("/titi.txt");
+            Assert.False(fs.FileExists("/titi.txt"));
+            fs.DeleteFile("/titi.bak.txt");
+            Assert.False(fs.FileExists("/titi.bak.txt"));
+        }
+
+        [Fact]
+        public void TestMoveFileDifferentDirectory()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            fs.CreateDirectory("/dir");
+
+            fs.MoveFile("/toto.txt", "/dir/titi.txt");
+
+            Assert.False(fs.FileExists("/toto.txt"));
+            Assert.True(fs.FileExists("/dir/titi.txt"));
+
+            Assert.Equal("content", fs.ReadAllText("/dir/titi.txt"));
+        }
+
+        [Fact]
+        public void TestReplaceFileDifferentDirectory()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            fs.CreateDirectory("/dir");
+            fs.WriteAllText("/dir/tata.txt", "content2");
+
+            fs.CreateDirectory("/dir2");
+
+            fs.ReplaceFile("/toto.txt", "/dir/tata.txt", "/dir2/titi.txt", true);
+            Assert.True(fs.FileExists("/dir/tata.txt"));
+            Assert.True(fs.FileExists("/dir2/titi.txt"));
+
+            Assert.Equal("content", fs.ReadAllText("/dir/tata.txt"));
+            Assert.Equal("content2", fs.ReadAllText("/dir2/titi.txt"));
+
+            fs.ReplaceFile("/dir/tata.txt", "/dir2/titi.txt", "/titi.txt", true);
+            Assert.False(fs.FileExists("/dir/tata.txt"));
+            Assert.True(fs.FileExists("/dir2/titi.txt"));
+            Assert.True(fs.FileExists("/titi.txt"));
+        }
+
+        [Fact]
+        public void TestOpenFileAppend()
+        {
+            fs.AppendAllText("/toto.txt", "content");
+            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.Equal("content", fs.ReadAllText("/toto.txt"));
+
+            fs.AppendAllText("/toto.txt", "content");
+            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.Equal("contentcontent", fs.ReadAllText("/toto.txt"));
+        }
+
+        [Fact]
+        public void TestOpenFileTruncate()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.Equal("content", fs.ReadAllText("/toto.txt"));
+
+            var stream = fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write);
+            stream.Dispose();
+            Assert.Equal<long>(0, fs.GetFileLength("/toto.txt"));
+            Assert.Equal("", fs.ReadAllText("/toto.txt"));
+        }
+
+        [Fact]
+        public void TestFileExceptions()
+        {
+            fs.CreateDirectory("/dir1");
+
+            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/toto.txt"));
+            Assert.Throws<FileNotFoundException>(() => fs.CopyFile("/toto.txt", "/toto.bak.txt", true));
+            Assert.Throws<UnauthorizedAccessException>(() => fs.CopyFile("/dir1", "/toto.bak.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.MoveFile("/toto.txt", "/titi.txt"));
+            // If the file to be deleted does not exist, no exception is thrown.
+            fs.DeleteFile("/toto.txt");
+            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read));
+            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/toto.txt", FileMode.Truncate, FileAccess.Write));
+
+            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/dir1/toto.txt"));
+            Assert.Throws<FileNotFoundException>(() => fs.CopyFile("/dir1/toto.txt", "/toto.bak.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.MoveFile("/dir1/toto.txt", "/titi.txt"));
+            // If the file to be deleted does not exist, no exception is thrown.
+            fs.DeleteFile("/dir1/toto.txt");
+            Assert.Throws<FileNotFoundException>(() => fs.OpenFile("/dir1/toto.txt", FileMode.Open, FileAccess.Read));
+
+            fs.WriteAllText("/toto.txt", "yo");
+            fs.CopyFile("/toto.txt", "/titi.txt", false);
+            fs.CopyFile("/toto.txt", "/titi.txt", true);
+
+            Assert.Throws<FileNotFoundException>(() => fs.GetFileLength("/dir1"));
+
+            var defaultTime = new DateTime(1601, 01, 01, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+            Assert.Equal(defaultTime, fs.GetCreationTime("/dest"));
+            Assert.Equal(defaultTime, fs.GetLastWriteTime("/dest"));
+            Assert.Equal(defaultTime, fs.GetLastAccessTime("/dest"));
+
+            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Assert.Throws<IOException>(() =>
+                {
+                    using (var stream2 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+                    {
+                    }
+                });
+            }
+
+            Assert.Throws<UnauthorizedAccessException>(() => fs.OpenFile("/dir1", FileMode.Open, FileAccess.Read));
+            Assert.Throws<DirectoryNotFoundException>(() => fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read));
+            Assert.Throws<DirectoryNotFoundException>(() => fs.CopyFile("/toto.txt", "/dest/toto.txt", true));
+            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/titi.txt", false));
+            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/dir1", true));
+            Assert.Throws<DirectoryNotFoundException>(() => fs.MoveFile("/toto.txt", "/dest/toto.txt"));
+
+            fs.WriteAllText("/titi.txt", "yo2");
+            Assert.Throws<IOException>(() => fs.MoveFile("/toto.txt", "/titi.txt"));
+
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/1.txt", default(UPath), true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/1.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/2.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/1.txt", "/2.txt", "/3.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/dir/2.txt", "/3.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/2.txt", "/3.txt", true));
+            Assert.Throws<FileNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/2.txt", "/toto.txt", true));
+
+            // Not same behavior in Physical vs Memory
+            if (fs is MemoryFileSystem)
+            {
+                Assert.Throws<DirectoryNotFoundException>(() => fs.ReplaceFile("/toto.txt", "/titi.txt", "/dir/3.txt", true));
+
+                fs.WriteAllText("/tata.txt", "yo3");
+                Assert.True(fs.FileExists("/tata.txt"));
+                fs.ReplaceFile("/toto.txt", "/titi.txt", "/tata.txt", true);
+                // TODO: check that tata.txt was correctly removed
+            }
+        }
+
+        [Fact]
+        public void TestDirectoryDeleteAndOpenFile()
+        {
+            fs.CreateDirectory("/dir");
+            fs.WriteAllText("/dir/toto.txt", "content");
+            var stream = fs.OpenFile("/dir/toto.txt", FileMode.Open, FileAccess.Read);
+
+            Assert.Throws<IOException>(() => fs.DeleteFile("/dir/toto.txt"));
+            Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir", true));
+
+            stream.Dispose();
+
+#if !NET472
+            fs.SetAttributes("/dir/toto.txt", FileAttributes.ReadOnly);
+            Assert.Throws<UnauthorizedAccessException>(() => fs.DeleteDirectory("/dir", true));
+            fs.SetAttributes("/dir/toto.txt", FileAttributes.Normal);
+#endif
+
+            fs.DeleteDirectory("/dir", true);
+
+            var entries = fs.EnumeratePaths("/").ToList();
+            Assert.Empty(entries);
+        }
+
+        [Fact]
+        public void TestOpenFileMultipleRead()
+        {
+            var memStream = new MemoryStream();
+            var writeSystem = new ZipArchiveFileSystem(memStream, ZipArchiveMode.Update, true);
+            writeSystem.WriteAllText("/toto.txt", "content");
+            writeSystem.Dispose();
+
+            var readSystem = new ZipArchiveFileSystem(memStream, ZipArchiveMode.Read, true);
+            Assert.True(readSystem.FileExists("/toto.txt"));
+            
+
+            using (var tmp = readSystem.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
+            {
+                Assert.Throws<IOException>(() => readSystem.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read));
+            }
+
+            var stream1 = readSystem.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
+            var stream2 = readSystem.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            // DeflateStream used by ZipArchive in read mode does not support Position and Length
+            //Assert.Equal<long>(1, stream1.Position);
+            Assert.Equal<char>('c', (char)stream1.ReadByte());
+
+            Assert.Equal<char>('c', (char)stream2.ReadByte());
+            //Assert.Equal<long>(2, stream2.Position);
+
+            stream1.Dispose();
+            stream2.Dispose();
+            
+            readSystem.Dispose();
+            
+            // We try to write back on the same file after closing
+            writeSystem = new ZipArchiveFileSystem(memStream, ZipArchiveMode.Update);
+            writeSystem.WriteAllText("/toto.txt", "content2");
+        }
+
+        [Fact]
+        public void TestOpenFileReadAndWriteFail()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            Assert.True(fs.FileExists("/toto.txt"));
+
+            var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read);
+
+            stream1.ReadByte();
+            Assert.Equal<long>(1, stream1.Position);
+
+            // We try to write back on the same file before closing
+            Assert.Throws<IOException>(() => fs.WriteAllText("/toto.txt", "content2"));
+
+            // Make sure that checking for a file exists or directory exists doesn't throw an exception "being used"
+            Assert.True(fs.FileExists("/toto.txt"));
+            Assert.False(fs.DirectoryExists("/toto.txt"));
+
+            stream1.Dispose();
+        }
+
+        // ZipArchive doesn't support opening multiple streams in Update and Create mode
+        /*[Fact]
+        public void TestOpenFileReadAndWriteShared()
+        {
+            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var stream2 = fs.OpenFile("/toto.txt", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                var buffer = Encoding.UTF8.GetBytes("abc");
+                stream1.Write(buffer, 0, buffer.Length);
+                stream1.Flush();
+
+                buffer = Encoding.UTF8.GetBytes("d");
+                stream2.Position = 1;
+                stream2.Write(buffer, 0, buffer.Length);
+                stream2.Flush();
+            }
+
+            var content = fs.ReadAllText("/toto.txt");
+            Assert.Equal("adc", content);
+        }
+
+        [Fact]
+        public void TestOpenFileReadAndWriteShared2()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            // No exceptions
+            using (var stream1 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                using (var stream2 = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                }
+            }
+            var content = fs.ReadAllText("/toto.txt");
+            Assert.Equal("content", content);
+        }*/
+
+        [Fact]
+        public void TestCopyFileToSameFile()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/toto.txt", true));
+            Assert.Throws<IOException>(() => fs.CopyFile("/toto.txt", "/toto.txt", false));
+
+            fs.CreateDirectory("/dir");
+
+            fs.WriteAllText("/dir/toto.txt", "content");
+            Assert.Throws<IOException>(() => fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", true));
+            Assert.Throws<IOException>(() => fs.CopyFile("/dir/toto.txt", "/dir/toto.txt", false));
+        }
+
+        [Fact]
+        public void TestEnumeratePaths()
+        {
+            fs.CreateDirectory("/dir1/a/b");
+            fs.CreateDirectory("/dir1/a1");
+            fs.CreateDirectory("/dir2/c");
+            fs.CreateDirectory("/dir3");
+
+            fs.WriteAllText("/dir1/a/file10.txt", "content10");
+            fs.WriteAllText("/dir1/a1/file11.txt", "content11");
+            fs.WriteAllText("/dir2/file20.txt", "content20");
+
+            fs.WriteAllText("/file01.txt", "content1");
+            fs.WriteAllText("/file02.txt", "content2");
+
+            var entries = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Both).ToList<UPath>();
+            entries.Sort();
+
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1",
+                    "/dir1/a",
+                    "/dir1/a/b",
+                    "/dir1/a/file10.txt",
+                    "/dir1/a1",
+                    "/dir1/a1/file11.txt",
+                    "/dir2",
+                    "/dir2/c",
+                    "/dir2/file20.txt",
+                    "/dir3",
+                    "/file01.txt",
+                    "/file02.txt",
+                }
+                , entries);
+
+
+            var folders = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.Directory).ToList<UPath>();
+            folders.Sort();
+
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1",
+                    "/dir1/a",
+                    "/dir1/a/b",
+                    "/dir1/a1",
+                    "/dir2",
+                    "/dir2/c",
+                    "/dir3",
+                }
+                , folders);
+
+
+            var files = fs.EnumeratePaths("/", "*", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            files.Sort();
+
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1/a/file10.txt",
+                    "/dir1/a1/file11.txt",
+                    "/dir2/file20.txt",
+                    "/file01.txt",
+                    "/file02.txt",
+                }
+                , files);
+
+
+            folders = fs.EnumeratePaths("/dir1", "a", SearchOption.AllDirectories, SearchTarget.Directory).ToList<UPath>();
+            folders.Sort();
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1/a",
+                }
+                , folders);
+
+
+            files = fs.EnumeratePaths("/dir1", "file1?.txt", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            files.Sort();
+
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1/a/file10.txt",
+                    "/dir1/a1/file11.txt",
+                }
+                , files);
+
+            files = fs.EnumeratePaths("/", "file?0.txt", SearchOption.AllDirectories, SearchTarget.File).ToList<UPath>();
+            files.Sort();
+
+            Assert.Equal(new List<UPath>()
+                {
+                    "/dir1/a/file10.txt",
+                    "/dir2/file20.txt",
+                }
+                , files);
+        }
+
+        [Fact]
+        public void TestMultithreaded()
+        {
+            fs.CreateDirectory("/dir1");
+            fs.WriteAllText("/toto.txt", "content");
+
+            const int CountTest = 2000;
+
+            var thread1 = new Thread(() =>
+            {
+                for (int i = 0; i < CountTest; i++)
+                {
+                    fs.CopyFile("/toto.txt", "/titi.txt", true);
+                    fs.MoveFile("/titi.txt", "/tata.txt");
+                    fs.MoveFile("/tata.txt", "/dir1/tata.txt");
+
+                    if (fs.FileExists("/dir1/tata.txt"))
+                    {
+                        fs.DeleteFile("/dir1/tata.txt");
+                    }
+                }
+            });
+            var thread2 = new Thread(() =>
+            {
+                for (int i = 0; i < CountTest; i++)
+                {
+                    fs.EnumeratePaths("/").ToList();
+                }
+            });
+
+            var thread3 = new Thread(() =>
+            {
+                for (int i = 0; i < CountTest; i++)
+                {
+                    fs.CreateDirectory("/dir2");
+                    fs.MoveDirectory("/dir2", "/dir1/dir3");
+                    fs.DeleteDirectory("/dir1/dir3", true);
+
+                    fs.CreateFile("/0.txt").Dispose();
+                    fs.DeleteFile("/0.txt");
+                }
+            });
+
+            thread1.Start();
+            thread2.Start();
+            thread3.Start();
+
+            thread1.Join();
+            thread2.Join();
+            thread3.Join();
+
+            fs.DeleteDirectory("/dir1", true);
+            fs.DeleteFile("/toto.txt");
+        }
+
+        [Fact]
+        public void TestOpenFileAppendAndRead()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                using (var stream = fs.OpenFile("/toto.txt", FileMode.Append, FileAccess.Read))
+                {
+                }
+            });
+        }
+
+        [Fact]
+        public void TestOpenFileCreateNewAlreadyExist()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            Assert.Throws<IOException>(() =>
+            {
+                using (var stream = fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write))
+                {
+                }
+            });
+
+            Assert.Throws<IOException>(() =>
+            {
+                using (var stream = fs.OpenFile("/toto.txt", FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite))
+                {
+                }
+            });
+        }
+
+        [Fact]
+        public void TestOpenFileCreate()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+
+            using (var stream = fs.OpenFile("/toto.txt", FileMode.Create, FileAccess.Write))
+            {
+            }
+
+            Assert.Equal(0, fs.GetFileLength("/toto.txt"));
+        }
+
+        [Fact]
+        public void TestMoveDirectorySubFolderFail()
+        {
+            fs.CreateDirectory("/dir");
+            fs.CreateDirectory("/dir/dir1");
+
+            Assert.Throws<IOException>(() => fs.MoveDirectory("/dir", "/dir/dir1/dir2"));
+        }
+
+        [Fact]
+        public void TestReplaceFileSameFileFail()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            Assert.Throws<IOException>(() => fs.ReplaceFile("/toto.txt", "/toto.txt", null, true));
+
+            fs.WriteAllText("/tata.txt", "content2");
+
+            Assert.Throws<IOException>(() => fs.ReplaceFile("/toto.txt", "/tata.txt", "/toto.txt", true));
+        }
+
+        [Fact]
+        public void TestStreamSeek()
+        {
+            //                            0123456
+            fs.WriteAllText("/toto.txt", "content", Encoding.ASCII);
+
+            using (var stream = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.Read))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                Assert.Equal((byte)'c', stream.ReadByte());
+                Assert.Equal((byte)'o', stream.ReadByte());
+
+                stream.Seek(3, SeekOrigin.Begin);
+                Assert.Equal((byte)'t', stream.ReadByte());
+
+                stream.Seek(1, SeekOrigin.Current);
+                Assert.Equal((byte)'n', stream.ReadByte());
+
+                stream.Seek(-3, SeekOrigin.End);
+                Assert.Equal((byte)'e', stream.ReadByte());
+
+                Assert.Throws<IOException>(() => stream.Seek(-1, SeekOrigin.Begin));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = -1);
+                stream.Position = 0;
+                Assert.Equal((byte)'c', stream.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void TestDispose()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            var stream = fs.OpenFile("/toto.txt", FileMode.Open, FileAccess.ReadWrite);
+            stream.Dispose();
+            stream.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
+            Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(1));
+            Assert.Throws<ObjectDisposedException>(() => stream.Position);
+            Assert.False(stream.CanRead);
+            Assert.False(stream.CanSeek);
+            Assert.False(stream.CanWrite);
+            Assert.Throws<ObjectDisposedException>(() => stream.Flush());
+            Assert.Throws<ObjectDisposedException>(() => stream.Length);
+            Assert.Throws<ObjectDisposedException>(() => stream.SetLength(0));
+            Assert.Throws<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void TestDeleteDirectoryNonEmpty()
+        {
+            fs.CreateDirectory("/dir/dir1");
+            Assert.Throws<IOException>(() => fs.DeleteDirectory("/dir", false));
+        }
+
+        [Fact]
+        public void TestInvalidCharacter()
+        {
+            Assert.Throws<NotSupportedException>(() => fs.CreateDirectory("/toto/ta:ta"));
+        }
+#if !NET472
+        [Fact]
+        public void TestFileAttributes()
+        {
+            fs.WriteAllText("/toto.txt", "content");
+            fs.SetAttributes("/toto.txt", 0);
+            Assert.Equal(FileAttributes.Normal, fs.GetAttributes("/toto.txt"));
+
+            fs.CreateDirectory("/dir");
+            fs.SetAttributes("/dir", 0);
+            Assert.Equal(FileAttributes.Directory, fs.GetAttributes("/dir"));
+        }
+#endif
+    }
+}

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -1,0 +1,1034 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+
+#if HAS_ZIPARCHIVE
+namespace Zio.FileSystems
+{
+    /// <summary>
+    ///     Provides a <see cref="IFileSystem" /> for the ZipArchive filesystem.
+    /// </summary>
+    public class ZipArchiveFileSystem : FileSystem
+    {
+        private readonly bool _isCaseSensitive;
+        
+        private readonly ZipArchive _archive;
+
+        private readonly ReaderWriterLockSlim _entriesLock = new();
+        
+        private FileSystemEventDispatcher<FileSystemWatcher>? _dispatcher;
+        private readonly object _dispatcherLock = new();
+        
+        private readonly DateTime _creationTime;
+
+        private readonly Dictionary<string, ZipArchiveEntry> _entries;
+        
+        private readonly Dictionary<ZipArchiveEntry, Pair<FileShare, int>> _openStreams;
+
+#if NET45 // .Net4.5 uses a backslash as directory separator
+        private const char DirectorySeparator = '\\';
+#else
+        private const char DirectorySeparator = '/';
+#endif
+
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ZipArchiveFileSystem" /> class.
+        /// </summary>
+        /// <param name="archive">An instance of <see cref="ZipArchive" /></param>
+        /// <param name="isCaseSensitive">Specifies if entry names should be case sensitive</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public ZipArchiveFileSystem(ZipArchive archive, bool isCaseSensitive = false)
+        {
+            _archive = archive;
+            _isCaseSensitive = isCaseSensitive;
+            _creationTime = DateTime.Now;
+            if (archive == null)
+            {
+                throw new ArgumentNullException(nameof(archive));
+            }
+#if NET45 // .Net4.5 uses a backslash as directory separator
+            foreach (var entry in _archive.Entries)
+            {
+                entry.FullName.Replace('/', DirectorySeparator);
+            }
+#else
+            foreach (var entry in _archive.Entries)
+            {
+                entry.FullName.Replace('\\', DirectorySeparator);
+            }
+#endif
+            if (!_isCaseSensitive)
+            {
+                _entries = _archive.Entries.ToDictionary(e => e.FullName.ToLowerInvariant(), e => e);
+            }
+
+            _openStreams = new Dictionary<ZipArchiveEntry, Pair<FileShare, int>>();
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ZipArchiveFileSystem" /> class.
+        /// </summary>
+        /// <param name="stream">Instance of stream to create <see cref="ZipArchive" /> from</param>
+        /// <param name="mode">Mode of <see cref="ZipArchive" /></param>
+        /// <param name="leaveOpen">True to leave the stream open when <see cref="ZipArchive" /> is disposed</param>
+        /// <param name="isCaseSensitive"></param>
+        public ZipArchiveFileSystem(Stream stream, ZipArchiveMode mode = ZipArchiveMode.Update, bool leaveOpen = false, bool isCaseSensitive = false)
+            : this(new ZipArchive(stream, mode, leaveOpen), isCaseSensitive)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ZipArchiveFileSystem" /> class from file.
+        /// </summary>
+        /// <param name="path">Path to zip file</param>
+        /// <param name="mode">Mode of <see cref="ZipArchive" /></param>
+        /// <param name="leaveOpen">True to leave the stream open when <see cref="ZipArchive" /> is disposed</param>
+        /// <param name="isCaseSensitive">Specifies if entry names should be case sensitive</param>
+        public ZipArchiveFileSystem(string path, ZipArchiveMode mode = ZipArchiveMode.Update, bool leaveOpen = false, bool isCaseSensitive = false)
+            : this(new ZipArchive(File.Open(path, FileMode.OpenOrCreate), mode, leaveOpen), isCaseSensitive)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ZipArchiveFileSystem" /> class with a <see cref="MemoryStream" />
+        /// </summary>
+        /// <param name="mode">Mode of <see cref="ZipArchive" /></param>
+        /// <param name="leaveOpen">True to leave the stream open when <see cref="ZipArchive" /> is disposed</param>
+        /// <param name="isCaseSensitive">Specifies if entry names should be case sensitive</param>
+        public ZipArchiveFileSystem(ZipArchiveMode mode = ZipArchiveMode.Update, bool leaveOpen = false, bool isCaseSensitive = false)
+            : this(new ZipArchive(new MemoryStream(), mode, leaveOpen), isCaseSensitive)
+        {
+        }
+
+        private ZipArchiveEntry? GetEntry(string path)
+        {
+#if NET45
+            path = path.Replace('/', DirectorySeparator);
+#else
+            path = path.Replace('\\', DirectorySeparator);
+#endif
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            path = RemoveLeadingSlash(path);
+
+            _entriesLock.EnterReadLock();
+            try
+            {
+                if (_isCaseSensitive)
+                {
+                    return _archive.GetEntry(path);
+                }
+
+                return _entries.TryGetValue(path.ToLowerInvariant(), out var foundEntry) ? foundEntry : null;
+            }
+            finally
+            {
+                _entriesLock.ExitReadLock();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override UPath ConvertPathFromInternalImpl(string innerPath)
+        {
+            return new UPath(innerPath);
+        }
+
+        /// <inheritdoc />
+        protected override string ConvertPathToInternalImpl(UPath path)
+        {
+            return path.FullName;
+        }
+
+        /// <inheritdoc />
+        protected override void CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
+        {
+            if (srcPath == destPath)
+            {
+                throw new IOException("Source and destination path must be different.");
+            }
+
+            var entry = GetEntry(srcPath.FullName);
+            if (entry == null)
+            {
+                if (DirectoryExistsImpl(srcPath))
+                {
+                    throw new UnauthorizedAccessException(nameof(srcPath) + " is a directory.");
+                }
+
+                if (!DirectoryExistsImpl(srcPath.GetDirectory()))
+                {
+                    throw new DirectoryNotFoundException(srcPath.GetDirectory().FullName);
+                }
+
+                throw FileSystemExceptionHelper.NewFileNotFoundException(srcPath);
+            }
+
+            var parentDirectory = destPath.GetDirectory();
+            if (!DirectoryExistsImpl(parentDirectory))
+            {
+                throw FileSystemExceptionHelper.NewDirectoryNotFoundException(parentDirectory);
+            }
+
+            if (DirectoryExistsImpl(destPath))
+            {
+                if (!FileExistsImpl(destPath))
+                {
+                    throw new IOException("Destination path is a directory");
+                }
+            }
+
+            var destEntry = GetEntry(destPath.FullName);
+            if (destEntry != null)
+            {
+#if NETSTANDARD2_1_OR_GREATER
+                if ((destEntry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
+                {
+                    throw new UnauthorizedAccessException("Destination file is read only");
+                }
+#endif
+                if (!overwrite)
+                {
+                    throw FileSystemExceptionHelper.NewDestinationFileExistException(srcPath);
+                }
+
+                RemoveEntry(destEntry);
+                TryGetDispatcher()?.RaiseDeleted(destPath);
+            }
+
+            destEntry = CreateEntry(destPath.FullName);
+            using (var destStream = destEntry.Open())
+            {
+                using var srcStream = entry == null ? new FileStream(srcPath.FullName, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite) : entry.Open();
+                srcStream.CopyTo(destStream);
+            }
+#if NETSTANDARD2_1_OR_GREATER
+            destEntry.ExternalAttributes = entry.ExternalAttributes | (int)FileAttributes.Archive;
+#endif
+            TryGetDispatcher()?.RaiseCreated(destPath);
+        }
+
+        /// <inheritdoc />
+        protected override void CreateDirectoryImpl(UPath path)
+        {
+            if (FileExistsImpl(path))
+            {
+                throw FileSystemExceptionHelper.NewDestinationFileExistException(path);
+            }
+
+            if (DirectoryExistsImpl(path))
+            {
+                throw FileSystemExceptionHelper.NewDestinationDirectoryExistException(path);
+            }
+
+            var parentPath = new UPath(GetParent(path.FullName));
+            if (parentPath != "")
+            {
+                if (!DirectoryExistsImpl(parentPath))
+                {
+                    CreateDirectoryImpl(parentPath);
+                }
+            }
+
+            var entryPath = RemoveLeadingSlash(path);
+#if NET45
+            entryPath = entryPath.Replace('/', DirectorySeparator);
+#else
+            entryPath = entryPath.Replace('\\', DirectorySeparator);
+#endif
+            CreateEntry(ConvertPathToDirectory(entryPath));
+            TryGetDispatcher()?.RaiseCreated(entryPath);
+        }
+
+        /// <inheritdoc />
+        protected override void DeleteDirectoryImpl(UPath path, bool isRecursive)
+        {
+            var entryPath = RemoveLeadingSlash(ConvertPathToDirectory(path));
+#if NET45
+            entryPath = entryPath.Replace('/', DirectorySeparator);
+#else
+            entryPath = entryPath.Replace('\\', DirectorySeparator);
+#endif
+            var entries = new List<ZipArchiveEntry>();
+            if (!isRecursive)
+            {
+                // folder name ends with slash so StartWith check is enough
+                _entriesLock.EnterReadLock();
+                try
+                {
+                    entries = _archive.Entries.Where(x => x.FullName.StartsWith(entryPath, _isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase)).Take(2).ToList();
+                }
+                finally
+                {
+                    _entriesLock.ExitReadLock();
+                }
+
+                if (entries.Count == 0)
+                {
+                    if (FileExistsImpl(path))
+                    {
+                        throw new IOException($"{path} is a file");
+                    }
+
+                    throw FileSystemExceptionHelper.NewDirectoryNotFoundException(path);
+                }
+
+                if (entries.Count == 1)
+                {
+                    RemoveEntry(entries[0]);
+                }
+
+                if (entries.Count == 2)
+                {
+                    throw new IOException("Directory is not empty");
+                }
+
+                TryGetDispatcher()?.RaiseDeleted(path);
+                return;
+            }
+
+            _entriesLock.EnterReadLock();
+            try
+            {
+                entries = _archive.Entries.Where(x => x.FullName.StartsWith(entryPath, _isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase)).ToList();
+                if (entries.Count == 0)
+                {
+                    entryPath = entryPath.Substring(0, entryPath.Length - 1);
+                    if (_isCaseSensitive ? _archive.GetEntry(entryPath) != null : _entries.ContainsKey(entryPath.ToLowerInvariant()))
+                    {
+                        throw new IOException($"{path} is a file");
+                    }
+
+                    throw FileSystemExceptionHelper.NewDirectoryNotFoundException(path);
+                }
+
+                // check if there are no open file in directory
+                foreach (var entry in entries)
+                {
+                    if (_openStreams.ContainsKey(entry))
+                    {
+                        throw new IOException($"There is an open file {entry.FullName} in directory");
+                    }
+                }
+#if NETSTANDARD2_1_OR_GREATER
+                // check if there are none readonly entries
+                foreach (var entry in entries)
+                {
+                    if ((entry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
+                    {
+                        throw entry.FullName == entryPath
+                            ? new IOException("Directory is read only")
+                            : new UnauthorizedAccessException($"Cannot delete directory that contains readonly entry {entry.FullName}");
+                    }
+                }
+#endif
+            }
+            finally
+            {
+                _entriesLock.ExitReadLock();
+            }
+
+            _entriesLock.EnterWriteLock();
+            try
+            {
+                foreach (var entry in entries)
+                {
+                    entry.Delete();
+
+                    if (!_isCaseSensitive)
+                    {
+                        _entries.Remove(entry.FullName.ToLowerInvariant());
+                    }
+                }
+            }
+            finally
+            {
+                _entriesLock.ExitWriteLock();
+            }
+
+            TryGetDispatcher()?.RaiseDeleted(path);
+        }
+
+        /// <inheritdoc />
+        protected override void DeleteFileImpl(UPath path)
+        {
+            if (DirectoryExistsImpl(path))
+            {
+                throw new IOException("Cannot delete a directory");
+            }
+
+            var entry = GetEntry(path.FullName);
+            if (entry == null)
+            {
+                return;
+            }
+#if NETSTANDARD2_1_OR_GREATER
+            if ((entry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
+            {
+                throw new UnauthorizedAccessException("Cannot delete file with readonly attribute");
+            }
+#endif
+
+            TryGetDispatcher()?.RaiseDeleted(path);
+            RemoveEntry(entry);
+        }
+
+        /// <inheritdoc />
+        protected override bool DirectoryExistsImpl(UPath path)
+        {
+            if (path.FullName is "/" or "\\" or "")
+            {
+                return true;
+            }
+
+            return GetEntry(ConvertPathToDirectory(path.FullName)) != null;
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            _archive.Dispose();
+
+            if (disposing)
+            {
+                TryGetDispatcher()?.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<FileSystemItem> EnumerateItemsImpl(UPath path, SearchOption searchOption, SearchPredicate? searchPredicate)
+        {
+            return EnumeratePathsStr(path, "*", searchOption, SearchTarget.Both).Select(p => new FileSystemItem(this, p, p[p.Length - 1] == DirectorySeparator));
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
+        {
+            return EnumeratePathsStr(path, searchPattern, searchOption, searchTarget).Select(x => new UPath(x));
+        }
+
+        private IEnumerable<string> EnumeratePathsStr(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
+        {
+            var search = SearchPattern.Parse(ref path, ref searchPattern);
+            var entryPath = RemoveLeadingSlash(path);
+            var root = ConvertPathToDirectory(entryPath);
+#if NET45
+            root = root.Replace('/', '\\');
+#else
+            root = root.Replace('\\', '/');
+#endif
+            _entriesLock.EnterReadLock();
+            var entriesList = new List<ZipArchiveEntry>();
+            try
+            {
+                entriesList = root == ""
+                    ? _archive.Entries.ToList()
+                    : _archive.Entries.Where(e => e.FullName.StartsWith(root, _isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) && e.FullName.Length > root.Length).ToList();
+            }
+            finally
+            {
+                _entriesLock.ExitReadLock();
+            }
+
+            if (entriesList.Count == 0)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var entries = (IEnumerable<ZipArchiveEntry>)entriesList;
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                var dir = GetParent(entries.First().FullName);
+                entries = entries.Where(e => string.Equals(ConvertPathToDirectory(GetParent(e.FullName)), root, _isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (searchTarget == SearchTarget.File)
+            {
+                entries = entries.Where(e => e.FullName[e.FullName.Length - 1] != DirectorySeparator);
+            }
+            else if (searchTarget == SearchTarget.Directory)
+            {
+                entries = entries.Where(e => e.FullName[e.FullName.Length - 1] == DirectorySeparator);
+            }
+
+            if (!string.IsNullOrEmpty(searchPattern))
+            {
+                entries = entries.Where(e => search.Match(GetName(e)));
+            }
+
+            return entries.Select(e => '/' + e.FullName);
+        }
+
+        /// <inheritdoc />
+        protected override bool FileExistsImpl(UPath path)
+        {
+            return GetEntry(path.FullName) != null;
+        }
+
+        /// <inheritdoc />
+        protected override FileAttributes GetAttributesImpl(UPath path)
+        {
+            var entry = GetEntry(path.FullName) ?? GetEntry(ConvertPathToDirectory(path));
+            if (entry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(path);
+            }
+
+            var attributes = entry.FullName[entry.FullName.Length - 1] == DirectorySeparator ? FileAttributes.Directory : 0;
+
+#if NETSTANDARD2_1_OR_GREATER
+            if (entry.ExternalAttributes == 0 && attributes == 0)
+            {
+                attributes |= FileAttributes.Normal;
+            }
+
+            return (FileAttributes)entry.ExternalAttributes | attributes;
+#endif
+            // return standard attributes if it's not NetStandard2.1
+            return attributes == FileAttributes.Directory ? FileAttributes.Directory : entry.LastWriteTime >= _creationTime ? FileAttributes.Archive : FileAttributes.Normal;
+        }
+
+        /// <inheritdoc />
+        protected override long GetFileLengthImpl(UPath path)
+        {
+            var entry = GetEntry(path.FullName);
+            if (entry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(path);
+            }
+
+            try
+            {
+                return entry.Length;
+            }
+            catch (Exception ex) // for some reason entry.Length doesn't work with MemoryStream used in tests
+            {
+                Debug.WriteLine(ex.Message);
+                using var stream = OpenFileImpl(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                return stream.Length;
+            }
+        }
+
+        /// <summary>
+        ///     Not supported by zip format. Return last write time.
+        /// </summary>
+        protected override DateTime GetCreationTimeImpl(UPath path)
+        {
+            return GetLastWriteTimeImpl(path);
+        }
+
+        /// <summary>
+        ///     Not supported by zip format. Return last write time
+        /// </summary>
+        protected override DateTime GetLastAccessTimeImpl(UPath path)
+        {
+            return GetLastWriteTimeImpl(path);
+        }
+
+        /// <inheritdoc />
+        protected override DateTime GetLastWriteTimeImpl(UPath path)
+        {
+            var entry = GetEntry(path.FullName) ?? GetEntry(ConvertPathToDirectory(path));
+            if (entry == null)
+            {
+                return DefaultFileTime;
+            }
+
+            return entry.LastWriteTime.DateTime;
+        }
+
+        /// <inheritdoc />
+        protected override void MoveDirectoryImpl(UPath srcPath, UPath destPath)
+        {
+            if (destPath.IsInDirectory(srcPath, true))
+            {
+                throw new IOException("Cannot move directory to itself or a subdirectory.");
+            }
+
+            var srcDir = RemoveLeadingSlash(ConvertPathToDirectory(srcPath.FullName));
+            var destDir = RemoveLeadingSlash(ConvertPathToDirectory(destPath.FullName));
+#if NET45
+            srcDir = srcDir.Replace('/', DirectorySeparator);
+            destDir = destDir.Replace('/', DirectorySeparator);
+#else
+            srcDir = srcDir.Replace('\\', DirectorySeparator);
+            destDir = destDir.Replace('\\', DirectorySeparator);
+#endif
+            _entriesLock.EnterReadLock();
+            var entries = new ZipArchiveEntry[0];
+            try
+            {
+                entries = _archive.Entries.Where(e => e.FullName.StartsWith(srcDir, _isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase)).ToArray();
+            }
+            finally
+            {
+                _entriesLock.ExitReadLock();
+            }
+
+            if (entries.Length == 0)
+            {
+                if (FileExistsImpl(srcPath))
+                {
+                    throw new IOException(nameof(srcPath) + " is a file.");
+                }
+
+                throw FileSystemExceptionHelper.NewDirectoryNotFoundException(srcPath);
+            }
+
+            CreateDirectoryImpl(destPath);
+            foreach (var entry in entries)
+            {
+                if (entry.FullName.Length == srcDir.Length)
+                {
+                    RemoveEntry(entry);
+                    continue;
+                }
+
+                using (var entryStream = entry.Open())
+                {
+                    var entryName = entry.FullName.Substring(srcDir.Length);
+                    var destEntry = CreateEntry(destDir + entryName);
+                    using (var destEntryStream = destEntry.Open())
+                    {
+                        entryStream.CopyTo(destEntryStream);
+                    }
+                }
+
+                TryGetDispatcher()?.RaiseCreated(destPath);
+                RemoveEntry(entry);
+                TryGetDispatcher()?.RaiseDeleted(srcPath);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void MoveFileImpl(UPath srcPath, UPath destPath)
+        {
+            var srcEntry = GetEntry(srcPath.FullName);
+            if (srcEntry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(srcPath);
+            }
+            
+            if (!DirectoryExistsImpl(destPath.GetDirectory()))
+            {
+                throw FileSystemExceptionHelper.NewDirectoryNotFoundException(destPath.GetDirectory());
+            }
+            
+            var destEntry = GetEntry(destPath.FullName);
+            if (destEntry != null)
+            {
+                throw new IOException("Cannot overwrite existing file.");
+            }
+            
+
+            destEntry = CreateEntry(destPath.FullName);
+            TryGetDispatcher()?.RaiseCreated(destPath);
+            using (var destStream = destEntry.Open())
+            {
+                using var srcStream = srcEntry.Open();
+                srcStream.CopyTo(destStream);
+            }
+
+            RemoveEntry(srcEntry);
+            TryGetDispatcher()?.RaiseDeleted(srcPath);
+        }
+
+        /// <inheritdoc />
+        protected override Stream OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share)
+        {
+            if (_archive.Mode == ZipArchiveMode.Read && access == FileAccess.Write)
+            {
+                throw new UnauthorizedAccessException("Cannot open a file for writing in a read-only archive.");
+            }
+
+            if (access == FileAccess.Read && (mode == FileMode.CreateNew || mode == FileMode.Create || mode == FileMode.Truncate || mode == FileMode.Append))
+            {
+                throw new ArgumentException("Cannot write in a read-only access.");
+            }
+
+            var entry = GetEntry(path.FullName);
+
+            if (entry == null)
+            {
+                if (mode is FileMode.Create or FileMode.CreateNew or FileMode.OpenOrCreate or FileMode.Append)
+                {
+                    entry = CreateEntry(path.FullName);
+#if NETSTANDARD2_1
+                    entry.ExternalAttributes = (int)FileAttributes.Archive;
+#endif
+                    TryGetDispatcher()?.RaiseCreated(path);
+                }
+                else
+                {
+                    if (DirectoryExistsImpl(path))
+                    {
+                        throw new UnauthorizedAccessException(nameof(path) + " is a directory.");
+                    }
+
+                    if (!DirectoryExistsImpl(path.GetDirectory()))
+                    {
+                        throw FileSystemExceptionHelper.NewDirectoryNotFoundException(path.GetDirectory());
+                    }
+
+                    throw FileSystemExceptionHelper.NewFileNotFoundException(path);
+                }
+            }
+            else if (mode == FileMode.CreateNew)
+            {
+                throw new IOException("Cannot create a file in CreateNew mode if it already exists.");
+            }
+            else if (mode == FileMode.Create)
+            {
+                RemoveEntry(entry);
+                entry = CreateEntry(path.FullName);
+            }
+
+#if NETSTANDARD2_1_OR_GREATER
+            if ((access == FileAccess.Write || access == FileAccess.ReadWrite) && (entry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
+            {
+                throw new UnauthorizedAccessException("Cannot open a file for writing in a file with readonly attribute.");
+            }
+#endif
+
+            var stream = new ZipEntryStream(share, this, entry);
+
+#if NETSTANDARD2_1_OR_GREATER
+            if (access is FileAccess.Write or FileAccess.ReadWrite)
+            {
+                entry.ExternalAttributes |= (int)FileAttributes.Archive;
+            }
+#endif
+
+            if (mode == FileMode.Append)
+            {
+                stream.Seek(0, SeekOrigin.End);
+            }
+            else if (mode == FileMode.Truncate)
+            {
+                stream.SetLength(0);
+            }
+
+            return stream;
+        }
+
+        /// <inheritdoc />
+        protected override void ReplaceFileImpl(UPath srcPath, UPath destPath, UPath destBackupPath, bool ignoreMetadataErrors)
+        {
+            var sourceEntry = GetEntry(srcPath.FullName);
+            if (sourceEntry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(srcPath);
+            }
+
+            var destEntry = GetEntry(destPath.FullName);
+            if (destEntry == sourceEntry)
+            {
+                throw new IOException("Cannot replace the file with itself.");
+            }
+
+            if (destEntry != null)
+            {
+                // create a backup at destBackupPath if its not null
+                if (destBackupPath != null)
+                {
+                    var destBackupEntry = CreateEntry(destBackupPath.FullName);
+                    using var destBackupStream = destBackupEntry.Open();
+                    using var destStream = destEntry.Open();
+                    destStream.CopyTo(destBackupStream);
+                }
+
+                RemoveEntry(destEntry);
+            }
+
+            var newEntry = CreateEntry(destPath.FullName);
+            using (var newStream = newEntry.Open())
+            {
+                using (var sourceStream = sourceEntry.Open())
+                {
+                    sourceStream.CopyTo(newStream);
+                }
+            }
+
+            RemoveEntry(sourceEntry);
+            TryGetDispatcher()?.RaiseDeleted(srcPath);
+            TryGetDispatcher()?.RaiseCreated(destPath);
+        }
+
+        /// <summary>
+        ///     Implementation for <see cref="SetAttributes" />, <paramref name="path" /> is guaranteed to be absolute and
+        ///     validated through <see cref="ValidatePath" />. Works only in Net Standard 2.1
+        ///     Sets the specified <see cref="FileAttributes" /> of the file or directory on the specified path.
+        /// </summary>
+        /// <param name="path">The path to the file or directory.</param>
+        /// <param name="attributes">A bitwise combination of the enumeration values.</param>
+        protected override void SetAttributesImpl(UPath path, FileAttributes attributes)
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            var entryPath = RemoveLeadingSlash(path);
+            var entry = GetEntry(entryPath) ?? GetEntry(ConvertPathToDirectory(entryPath));
+            if (entry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(path);
+            }
+
+            entry.ExternalAttributes = (int)attributes;
+            TryGetDispatcher()?.RaiseChange(path);
+            return;
+#endif
+            Debug.WriteLine("SetAttributes don't work in NetStandard2.0 or older.");
+        }
+
+        /// <summary>
+        ///     Not supported by zip format. Does nothing.
+        /// </summary>
+        protected override void SetCreationTimeImpl(UPath path, DateTime time)
+        {
+
+        }
+
+        /// <summary>
+        ///     Not supported by zip format. Does nothing.
+        /// </summary>
+        protected override void SetLastAccessTimeImpl(UPath path, DateTime time)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void SetLastWriteTimeImpl(UPath path, DateTime time)
+        {
+            var entry = GetEntry(path.FullName) ?? GetEntry(ConvertPathToDirectory(path.FullName));
+            if (entry == null)
+            {
+                throw FileSystemExceptionHelper.NewFileNotFoundException(path);
+            }
+
+            TryGetDispatcher()?.RaiseChange(path);
+            entry.LastWriteTime = time;
+        }
+
+        /// <inheritdoc />
+        protected override IFileSystemWatcher WatchImpl(UPath path)
+        {
+            var watcher = new FileSystemWatcher(this, path);
+            lock (_dispatcherLock)
+            {
+                _dispatcher ??= new FileSystemEventDispatcher<FileSystemWatcher>(this);
+                _dispatcher.Add(watcher);
+            }
+
+            return watcher;
+        }
+
+        private void RemoveEntry(ZipArchiveEntry entry)
+        {
+            _entriesLock.EnterWriteLock();
+            try
+            {
+                entry.Delete();
+
+                if (!_isCaseSensitive)
+                {
+                    _entries.Remove(entry.FullName.ToLowerInvariant());
+                }
+            }
+            finally
+            {
+                _entriesLock.ExitWriteLock();
+            }
+        }
+
+        private ZipArchiveEntry CreateEntry(string path)
+        {
+            path = RemoveLeadingSlash(path);
+#if NET45
+            path = path.Replace('/', DirectorySeparator);
+#else
+            path = path.Replace('\\', DirectorySeparator);
+#endif
+            _entriesLock.EnterWriteLock();
+            try
+            {
+                var entry = _archive.CreateEntry(path);
+
+                if (!_isCaseSensitive)
+                {
+                    _entries.Add(entry.FullName.ToLowerInvariant(), entry);
+                }
+
+                return entry;
+            }
+            finally
+            {
+                _entriesLock.ExitWriteLock();
+            }
+        }
+
+        private string GetName(ZipArchiveEntry entry)
+        {
+            var name = entry.FullName.TrimEnd('/', '\\');
+            var index = name.LastIndexOfAny(new[] { '/', '\\' });
+            return name.Substring(index + 1);
+        }
+
+        private static string GetParent(string path)
+        {
+            path = path.TrimEnd('/', '\\');
+            var lastIndex = path.LastIndexOfAny(new[] { '/', '\\' });
+            return lastIndex == -1 ? "" : path.Substring(0, lastIndex);
+        }
+
+        private static string ConvertPathToDirectory(UPath path)
+        {
+            return ConvertPathToDirectory(path.FullName);
+        }
+
+        private static string ConvertPathToDirectory(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            return path[path.Length - 1] is DirectorySeparator ? path : path + DirectorySeparator;
+        }
+
+        private static string RemoveLeadingSlash(UPath path)
+        {
+            return path.FullName[0] is '\\' or '/' ? path.FullName.Substring(1) : path.FullName;
+        }
+
+        private static string RemoveLeadingSlash(string path)
+        {
+            return path[0] is '\\' or '/' ? path.Substring(1) : path;
+        }
+
+        private FileSystemEventDispatcher<FileSystemWatcher>? TryGetDispatcher()
+        {
+            lock (_dispatcherLock)
+            {
+                return _dispatcher;
+            }
+        }
+
+
+        private class ZipEntryStream : Stream
+        {
+            private readonly ZipArchiveEntry _entry;
+            private readonly ZipArchiveFileSystem _fileSystem;
+            private readonly Stream _streamImplementation;
+            private bool _isDisposed;
+
+            public ZipEntryStream(FileShare share, ZipArchiveFileSystem system, ZipArchiveEntry entry)
+            {
+                _entry = entry;
+                _fileSystem = system;
+                var fileShare = _fileSystem._openStreams.TryGetValue(entry, out var fileData) ? fileData.First : FileShare.ReadWrite;
+                if (fileData != null)
+                {
+                    // we only check for read share, because ZipArchive doesn't support write share
+                    if (share is not FileShare.Read and not FileShare.ReadWrite)
+                    {
+                        throw new IOException("File is already opened for reading");
+                    }
+
+                    if (fileShare is not FileShare.Read and not FileShare.ReadWrite)
+                    {
+                        throw new IOException("File is already opened for reading by another stream with non compatible share");
+                    }
+
+                    fileData.Second++;
+                }
+                else
+                {
+                    _fileSystem._openStreams.Add(_entry, new Pair<FileShare, int>(share, 1));
+                }
+
+                Share = share;
+                _streamImplementation = entry.Open();
+            }
+
+            private FileShare Share { get; }
+
+            public override bool CanRead => _streamImplementation.CanRead;
+
+            public override bool CanSeek => _streamImplementation.CanSeek;
+
+            public override bool CanWrite => _streamImplementation.CanWrite;
+
+            public override long Length => _streamImplementation.Length;
+
+            public override long Position
+            {
+                get => _streamImplementation.Position;
+                set => _streamImplementation.Position = value;
+            }
+
+            public override void Flush()
+            {
+                _streamImplementation.Flush();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return _streamImplementation.Read(buffer, offset, count);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return _streamImplementation.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                _streamImplementation.SetLength(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _streamImplementation.Write(buffer, offset, count);
+            }
+
+            public override void Close()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                _streamImplementation.Close();
+                _isDisposed = true;
+                _fileSystem._openStreams.TryGetValue(_entry, out var fileData);
+                fileData.Second--;
+                if (fileData.Second == 0)
+                {
+                    _fileSystem._openStreams.Remove(_entry);
+                }
+            }
+        }
+
+        private class Pair<T, U>
+        {
+            public Pair(T first, U second)
+            {
+                First = first;
+                Second = second;
+            }
+
+            public T First { get; }
+            public U Second { get; set; }
+        }
+    }
+}
+#endif

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -159,8 +159,8 @@ namespace Zio.FileSystems
                 throw new IOException("Source and destination path must be different.");
             }
 
-            var entry = GetEntry(srcPath.FullName);
-            if (entry == null)
+            var srcEntry = GetEntry(srcPath.FullName);
+            if (srcEntry == null)
             {
                 if (DirectoryExistsImpl(srcPath))
                 {
@@ -210,11 +210,11 @@ namespace Zio.FileSystems
             destEntry = CreateEntry(destPath.FullName);
             using (var destStream = destEntry.Open())
             {
-                using var srcStream = entry == null ? new FileStream(srcPath.FullName, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite) : entry.Open();
+                using var srcStream = srcEntry.Open();
                 srcStream.CopyTo(destStream);
             }
 #if NETSTANDARD2_1_OR_GREATER
-            destEntry.ExternalAttributes = entry.ExternalAttributes | (int)FileAttributes.Archive;
+            destEntry.ExternalAttributes = srcEntry.ExternalAttributes | (int)FileAttributes.Archive;
 #endif
             TryGetDispatcher()?.RaiseCreated(destPath);
         }

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -948,7 +948,7 @@ namespace Zio.FileSystems
                         throw new IOException("File is already opened for reading by another stream with non compatible share");
                     }
 
-                    fileData.Count++;
+                    Interlocked.Increment(ref fileData.Count);
                 }
                 else
                 {
@@ -1010,7 +1010,7 @@ namespace Zio.FileSystems
                 _streamImplementation.Close();
                 _isDisposed = true;
                 _fileSystem._openStreams.TryGetValue(_entry, out var fileData);
-                fileData.Count--;
+                Interlocked.Decrement(ref fileData.Count);
                 if (fileData.Count == 0)
                 {
                     _fileSystem._openStreams.Remove(_entry);
@@ -1027,7 +1027,9 @@ namespace Zio.FileSystems
             }
 
             public FileShare Share { get; }
-            public int Count { get; set; }
+
+            public int Count;
+
         }
     }
 }

--- a/src/Zio/Zio.csproj
+++ b/src/Zio/Zio.csproj
@@ -34,6 +34,30 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.IO.Compression">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.IO.Compression">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.IO.Compression.ZipFile">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.IO.Compression">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.IO.Compression.ZipFile">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Adds ZipArchive support as a new file system

I think it's ready to merge

ZipArchive only supports attributes in NetStandard2.1 and last access/creation times are not supported by zip format so I copied compact tests, hope that's not a problem :)