### PR TITLE
Fix changing directory times

### DIFF
--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -89,6 +89,19 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             fs.CreateDirectory(pathToCreate);
             Assert.True(Directory.Exists(systemPathToCreate));
 
+            // LastAccessTime
+            // LastWriteTime
+            // CreationTime
+            var lastWriteTime = DateTime.Now + TimeSpan.FromSeconds(10);
+            var lastAccessTime = DateTime.Now + TimeSpan.FromSeconds(11);
+            var creationTime = DateTime.Now + TimeSpan.FromSeconds(12);
+            fs.SetLastWriteTime(pathToCreate, lastWriteTime);
+            fs.SetLastAccessTime(pathToCreate, lastAccessTime);
+            fs.SetCreationTime(pathToCreate, creationTime);
+            Assert.Equal(lastWriteTime, fs.GetLastWriteTime(pathToCreate));
+            Assert.Equal(lastAccessTime, fs.GetLastAccessTime(pathToCreate));
+            Assert.Equal(creationTime, fs.GetCreationTime(pathToCreate));
+
             // DirectoryExists
             Assert.True(fs.DirectoryExists(pathToCreate));
             Assert.False(fs.DirectoryExists(pathToCreate / "not_found"));

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -302,7 +302,17 @@ public class PhysicalFileSystem : FileSystem
             throw new UnauthorizedAccessException($"Cannot set creation time on system directory `{path}`");
         }
 
-        File.SetCreationTime(ConvertPathToInternal(path), time);
+        var internalPath = ConvertPathToInternal(path);
+        var attributes = File.GetAttributes(internalPath);
+
+        if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+        {
+            Directory.SetCreationTime(internalPath, time);
+        }
+        else
+        {
+            File.SetCreationTime(internalPath, time);
+        }
     }
 
     /// <inheritdoc />
@@ -353,7 +363,18 @@ public class PhysicalFileSystem : FileSystem
             }
             throw new UnauthorizedAccessException($"Cannot set last access time on system directory `{path}`");
         }
-        File.SetLastAccessTime(ConvertPathToInternal(path), time);
+
+        var internalPath = ConvertPathToInternal(path);
+        var attributes = File.GetAttributes(internalPath);
+
+        if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+        {
+            Directory.SetLastAccessTime(internalPath, time);
+        }
+        else
+        {
+            File.SetLastAccessTime(internalPath, time);
+        }
     }
 
     /// <inheritdoc />
@@ -405,7 +426,17 @@ public class PhysicalFileSystem : FileSystem
             throw new UnauthorizedAccessException($"Cannot set last write time on system directory `{path}`");
         }
 
-        File.SetLastWriteTime(ConvertPathToInternal(path), time);
+        var internalPath = ConvertPathToInternal(path);
+        var attributes = File.GetAttributes(internalPath);
+
+        if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+        {
+            Directory.SetLastWriteTime(internalPath, time);
+        }
+        else
+        {
+            File.SetLastWriteTime(internalPath, time);
+        }
     }
 
     // ----------------------------------------------


### PR DESCRIPTION
This PR fixes the following methods when the path is a directory:

- SetCreationTime
- SetLastAccessTime
- SetLastWriteTime


The current implementation uses `File`, which is invalid for directories. When you try to invoke the method with a directory path, you'll get the following exception (.NET 8 and .NET FX 4.8):

```
System.UnauthorizedAccessException
Access to the path 'C:\Sources\zio\src\Zio.Tests\bin\Debug\net472\TestCreateDirectory' is denied.
```

The XML documentation is not clear whether this should be supported or not. In the summary it says changing the file time:

https://github.com/xoofx/zio/blob/ae0b1ca58e0d59de1bd530fe4261a9fcbbb757c2/src/Zio/IFileSystem.cs#L131-L133

But in the path-param it's saying it accepts files and directories:

https://github.com/xoofx/zio/blob/ae0b1ca58e0d59de1bd530fe4261a9fcbbb757c2/src/Zio/IFileSystem.cs#L134

If we decide to merge this PR, should we change the XML documentation summary, so it mentions directories as well?

