### PR TITLE
Add symlink support

### DIFF
--- a/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
+++ b/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
@@ -120,6 +120,11 @@ public class FileSystemEntryRedirect : FileSystem
         _fs.GetFileSystemEntry(path).LastWriteTime = time;
     }
 
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        _fs.CreateSymbolicLink(path, pathToTarget);
+    }
+
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     {
         return _fs.GetDirectoryEntry(path).EnumerateEntries(searchPattern, searchOption, searchTarget).Select(e => e.Path);

--- a/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
+++ b/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
@@ -125,6 +125,11 @@ public class FileSystemEntryRedirect : FileSystem
         _fs.CreateSymbolicLink(path, pathToTarget);
     }
 
+    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    {
+        return _fs.ResolveLinkTarget(linkPath);
+    }
+
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     {
         return _fs.GetDirectoryEntry(path).EnumerateEntries(searchPattern, searchOption, searchTarget).Select(e => e.Path);

--- a/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
+++ b/src/Zio.Tests/FileSystems/FileSystemEntryRedirect.cs
@@ -125,9 +125,9 @@ public class FileSystemEntryRedirect : FileSystem
         _fs.CreateSymbolicLink(path, pathToTarget);
     }
 
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
-        return _fs.ResolveLinkTarget(linkPath);
+        return _fs.TryResolveLinkTarget(linkPath, out resolvedPath);
     }
 
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)

--- a/src/Zio.Tests/FileSystems/TestMountFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestMountFileSystem.cs
@@ -453,10 +453,10 @@ public class TestMountFileSystem : TestFileSystemBase
         var pathInfo = physicalFs.ConvertPathFromInternal(SystemPath).ToRelative();
         var pathSource = "/physical" / pathInfo / "Source";
         var filePathSource = pathSource / "test.txt";
-        var systemPathSource = fs.ConvertPathToInternal(pathSource);
+        var systemPathSource = Path.Combine(SystemPath, "Source");
         var pathDest = "/physical" / pathInfo / "Dest";
         var filePathDest = pathDest / "test.txt";
-        var systemPathDest = fs.ConvertPathToInternal(pathDest);
+        var systemPathDest = Path.Combine(SystemPath, "Dest");
 
         try
         {

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -443,7 +443,8 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             fs.CreateSymbolicLink(pathDest, pathSource);
 
             // ResolveSymbolicLink
-            Assert.Equal(pathSource, fs.ResolveLinkTarget(pathDest));
+            Assert.True(fs.TryResolveLinkTarget(pathDest, out var resolvedPath));
+            Assert.Equal(pathSource, resolvedPath);
 
             // FileExists
             Assert.True(fs.FileExists(filePathDest));
@@ -491,7 +492,8 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             fs.CreateSymbolicLink(pathDest, pathSource);
 
             // ResolveSymbolicLink
-            Assert.Equal(pathSource, fs.ResolveLinkTarget(pathDest));
+            Assert.True(fs.TryResolveLinkTarget(pathDest, out var resolvedPath));
+            Assert.Equal(pathSource, resolvedPath);
 
             // FileExists
             Assert.True(fs.FileExists(pathDest));

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -442,6 +442,9 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             // CreateSymbolicLink
             fs.CreateSymbolicLink(pathDest, pathSource);
 
+            // ResolveSymbolicLink
+            Assert.Equal(pathSource, fs.ResolveLinkTarget(pathDest));
+
             // FileExists
             Assert.True(fs.FileExists(filePathDest));
             Assert.Equal(buffer.Length, fs.GetFileLength(filePathDest));
@@ -486,6 +489,9 @@ public class TestPhysicalFileSystem : TestFileSystemBase
 
             // CreateSymbolicLink
             fs.CreateSymbolicLink(pathDest, pathSource);
+
+            // ResolveSymbolicLink
+            Assert.Equal(pathSource, fs.ResolveLinkTarget(pathDest));
 
             // FileExists
             Assert.True(fs.FileExists(pathDest));

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -445,6 +445,11 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             // FileExists
             Assert.True(fs.FileExists(filePathDest));
             Assert.Equal(buffer.Length, fs.GetFileLength(filePathDest));
+
+            // RemoveDirectory
+            fs.DeleteDirectory(pathDest, false);
+            Assert.False(Directory.Exists(systemPathDest));
+            Assert.True(Directory.Exists(systemPathSource));
         }
         finally
         {
@@ -500,6 +505,11 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             // FileEntry
             var entry = fs.GetFileSystemEntry(pathDest);
             Assert.True(entry.Attributes.HasFlag(FileAttributes.ReparsePoint));
+
+            // DeleteFile
+            fs.DeleteFile(pathDest);
+            Assert.False(File.Exists(systemPathDest));
+            Assert.True(File.Exists(systemPathSource));
         }
         finally
         {

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using System.IO;
+using System.Security.Principal;
 using System.Text;
 
 using Zio.FileSystems;
@@ -398,6 +399,112 @@ public class TestPhysicalFileSystem : TestFileSystemBase
         finally
         {
             SafeDeleteFile(systemFilePath);
+        }
+    }
+
+    [SkippableFact]
+    public void TestDirectorySymlink()
+    {
+#if NETCOREAPP
+        if (OperatingSystem.IsWindows())
+#else
+        if (IsWindows)
+#endif
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+
+            Skip.IfNot(principal.IsInRole(WindowsBuiltInRole.Administrator), "This test requires to be run as an administrator on Windows");
+        }
+
+        var fs = new PhysicalFileSystem();
+        var pathInfo = fs.ConvertPathFromInternal(SystemPath);
+        var pathSource = pathInfo / "Source";
+        var filePathSource = pathSource / "test.txt";
+        var systemPathSource = fs.ConvertPathToInternal(pathSource);
+        var pathDest = pathInfo / "Dest";
+        var filePathDest = pathDest / "test.txt";
+        var systemPathDest = fs.ConvertPathToInternal(pathDest);
+        try
+        {
+            // CreateDirectory
+            Assert.False(Directory.Exists(systemPathSource));
+            fs.CreateDirectory(pathSource);
+            Assert.True(Directory.Exists(systemPathSource));
+
+            // CreateFile / OpenFile
+            var fileStream = fs.CreateFile(filePathSource);
+            var buffer = Encoding.UTF8.GetBytes("This is a test");
+            fileStream.Write(buffer, 0, buffer.Length);
+            fileStream.Dispose();
+            Assert.Equal(buffer.Length, fs.GetFileLength(filePathSource));
+
+            // CreateSymbolicLink
+            fs.CreateSymbolicLink(pathDest, pathSource);
+
+            // FileExists
+            Assert.True(fs.FileExists(filePathDest));
+            Assert.Equal(buffer.Length, fs.GetFileLength(filePathDest));
+        }
+        finally
+        {
+            SafeDeleteDirectory(systemPathSource);
+            SafeDeleteDirectory(systemPathDest);
+        }
+    }
+
+    [SkippableFact]
+    public void TestFileSymlink()
+    {
+#if NETCOREAPP
+        if (OperatingSystem.IsWindows())
+#else
+        if (IsWindows)
+#endif
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+
+            Skip.IfNot(principal.IsInRole(WindowsBuiltInRole.Administrator), "This test requires to be run as an administrator on Windows");
+        }
+
+        var fs = new PhysicalFileSystem();
+        var pathInfo = fs.ConvertPathFromInternal(SystemPath);
+        var pathSource = pathInfo / "source.txt";
+        var systemPathSource = fs.ConvertPathToInternal(pathSource);
+        var pathDest = pathInfo / "dest.txt";
+        var systemPathDest = fs.ConvertPathToInternal(pathDest);
+        try
+        {
+            // CreateEmptyFile
+            fs.CreateFile(pathSource).Dispose();
+
+            // CreateSymbolicLink
+            fs.CreateSymbolicLink(pathDest, pathSource);
+
+            // FileExists
+            Assert.True(fs.FileExists(pathDest));
+
+            // CreateFile / OpenFile
+            var fileStream = fs.OpenFile(pathSource, FileMode.Open, FileAccess.ReadWrite);
+            var buffer = Encoding.UTF8.GetBytes("This is a test");
+            fileStream.Write(buffer, 0, buffer.Length);
+            fileStream.Dispose();
+            Assert.Equal(buffer.Length, fs.GetFileLength(pathSource));
+
+            // ReadAllBytes
+            // Note: we can't check the length, since on Windows the symlink length is 0
+            var symlinkBuffer = fs.ReadAllBytes(pathDest);
+            Assert.Equal(buffer, symlinkBuffer);
+
+            // FileEntry
+            var entry = fs.GetFileSystemEntry(pathDest);
+            Assert.True(entry.Attributes.HasFlag(FileAttributes.ReparsePoint));
+        }
+        finally
+        {
+            SafeDeleteFile(systemPathSource);
+            SafeDeleteFile(systemPathDest);
         }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -3,7 +3,8 @@
 // See the license.txt file in the project root for more information.
 
 using System.IO;
-
+using System.Security.Principal;
+using System.Text;
 using Zio.FileSystems;
 
 namespace Zio.Tests.FileSystems;
@@ -67,5 +68,73 @@ public class TestSubFileSystem : TestFileSystemBase
         fs.WriteAllText("/a/b/watched.txt", "test");
         System.Threading.Thread.Sleep(100);
         Assert.True(gotChange);
+    }
+
+
+    [SkippableFact]
+    public void TestDirectorySymlink()
+    {
+#if NETCOREAPP
+        if (OperatingSystem.IsWindows())
+#else
+        if (IsWindows)
+#endif
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+
+            Skip.IfNot(principal.IsInRole(WindowsBuiltInRole.Administrator), "This test requires to be run as an administrator on Windows");
+        }
+
+        var physicalFs = new PhysicalFileSystem();
+        var memoryFs = new MemoryFileSystem();
+        var fs = new MountFileSystem();
+        fs.Mount("/physical", physicalFs);
+        fs.Mount("/memory", memoryFs);
+
+        var pathInfo = physicalFs.ConvertPathFromInternal(SystemPath).ToRelative();
+        var pathSource = "/physical" / pathInfo / "Source";
+        var filePathSource = pathSource / "test.txt";
+        var systemPathSource = fs.ConvertPathToInternal(pathSource);
+        var pathDest = "/physical" / pathInfo / "Dest";
+        var filePathDest = pathDest / "test.txt";
+        var systemPathDest = fs.ConvertPathToInternal(pathDest);
+
+        try
+        {
+            // CreateDirectory
+            Assert.False(Directory.Exists(systemPathSource));
+            fs.CreateDirectory(pathSource);
+            Assert.True(Directory.Exists(systemPathSource));
+
+            // CreateFile / OpenFile
+            var fileStream = fs.CreateFile(filePathSource);
+            var buffer = Encoding.UTF8.GetBytes("This is a test");
+            fileStream.Write(buffer, 0, buffer.Length);
+            fileStream.Dispose();
+            Assert.Equal(buffer.Length, fs.GetFileLength(filePathSource));
+
+            // CreateSymbolicLink
+            fs.CreateSymbolicLink(pathDest, pathSource);
+            Assert.Throws<InvalidOperationException>(() => fs.CreateSymbolicLink("/memory/invalid", pathSource));
+
+            // ResolveSymbolicLink
+            Assert.True(fs.TryResolveLinkTarget(pathDest, out var resolvedPath));
+            Assert.Equal(pathSource, resolvedPath);
+
+            // FileExists
+            Assert.True(fs.FileExists(filePathDest));
+            Assert.Equal(buffer.Length, fs.GetFileLength(filePathDest));
+
+            // RemoveDirectory
+            fs.DeleteDirectory(pathDest, false);
+            Assert.False(Directory.Exists(systemPathDest));
+            Assert.True(Directory.Exists(systemPathSource));
+        }
+        finally
+        {
+            SafeDeleteDirectory(systemPathSource);
+            SafeDeleteDirectory(systemPathDest);
+        }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -70,7 +70,6 @@ public class TestSubFileSystem : TestFileSystemBase
         Assert.True(gotChange);
     }
 
-
     [SkippableFact]
     public void TestDirectorySymlink()
     {
@@ -87,16 +86,12 @@ public class TestSubFileSystem : TestFileSystemBase
         }
 
         var physicalFs = new PhysicalFileSystem();
-        var memoryFs = new MemoryFileSystem();
-        var fs = new MountFileSystem();
-        fs.Mount("/physical", physicalFs);
-        fs.Mount("/memory", memoryFs);
+        var fs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(SystemPath));
 
-        var pathInfo = physicalFs.ConvertPathFromInternal(SystemPath).ToRelative();
-        var pathSource = "/physical" / pathInfo / "Source";
+        UPath pathSource = "/Source";
         var filePathSource = pathSource / "test.txt";
         var systemPathSource = fs.ConvertPathToInternal(pathSource);
-        var pathDest = "/physical" / pathInfo / "Dest";
+        UPath pathDest = "/Dest";
         var filePathDest = pathDest / "test.txt";
         var systemPathDest = fs.ConvertPathToInternal(pathDest);
 
@@ -116,7 +111,6 @@ public class TestSubFileSystem : TestFileSystemBase
 
             // CreateSymbolicLink
             fs.CreateSymbolicLink(pathDest, pathSource);
-            Assert.Throws<InvalidOperationException>(() => fs.CreateSymbolicLink("/memory/invalid", pathSource));
 
             // ResolveSymbolicLink
             Assert.True(fs.TryResolveLinkTarget(pathDest, out var resolvedPath));

--- a/src/Zio.Tests/Zio.Tests.csproj
+++ b/src/Zio.Tests/Zio.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Zio.sln.DotSettings
+++ b/src/Zio.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Copyright (c) Alexandre Mutel. All rights reserved.&#xD;
 This file is licensed under the BSD-Clause 2 license. &#xD;
 See the license.txt file in the project root for more information.</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Zio/FileEntry.cs
+++ b/src/Zio/FileEntry.cs
@@ -284,7 +284,7 @@ public class FileEntry : FileSystemEntry
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesnâ€™t exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public void AppendAllText(string content)
@@ -301,7 +301,7 @@ public class FileEntry : FileSystemEntry
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesnâ€™t exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public void AppendAllText(string content, Encoding encoding)

--- a/src/Zio/FileEntry.cs
+++ b/src/Zio/FileEntry.cs
@@ -284,7 +284,7 @@ public class FileEntry : FileSystemEntry
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesn't exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public void AppendAllText(string content)
@@ -301,7 +301,7 @@ public class FileEntry : FileSystemEntry
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesn't exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public void AppendAllText(string content, Encoding encoding)

--- a/src/Zio/FileSystemExtensions.cs
+++ b/src/Zio/FileSystemExtensions.cs
@@ -504,7 +504,7 @@ public static class FileSystemExtensions
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesn't exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public static void AppendAllText(this IFileSystem fs, UPath path, string content)
@@ -531,7 +531,7 @@ public static class FileSystemExtensions
     /// <remarks>
     ///     Given a string and a file path, this method opens the specified file, appends the string to the end of the file,
     ///     and then closes the file. The file handle is guaranteed to be closed by this method, even if exceptions are raised.
-    ///     The method creates the file if it doesn’t exist, but it doesn't create new directories. Therefore, the value of the
+    ///     The method creates the file if it doesn't exist, but it doesn't create new directories. Therefore, the value of the
     ///     path parameter must contain existing directories.
     /// </remarks>
     public static void AppendAllText(this IFileSystem fs, UPath path, string content, Encoding encoding)

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -192,6 +192,14 @@ public abstract class ComposeFileSystem : FileSystem
         FallbackSafe.CreateSymbolicLink(ConvertPathToDelegate(path), ConvertPathToDelegate(pathToTarget));
     }
 
+    /// <inheritdoc />
+    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    {
+        var path = FallbackSafe.ResolveLinkTarget(ConvertPathToDelegate(linkPath));
+
+        return path.HasValue ? ConvertPathFromDelegate(path.Value) : default(UPath?);
+    }
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -193,11 +193,16 @@ public abstract class ComposeFileSystem : FileSystem
     }
 
     /// <inheritdoc />
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
-        var path = FallbackSafe.ResolveLinkTarget(ConvertPathToDelegate(linkPath));
+        if (!FallbackSafe.TryResolveLinkTarget(ConvertPathToDelegate(linkPath), out var resolvedPathDelegate))
+        {
+            resolvedPath = default;
+            return false;
+        }
 
-        return path.HasValue ? ConvertPathFromDelegate(path.Value) : default(UPath?);
+        resolvedPath = ConvertPathFromDelegate(resolvedPathDelegate);
+        return true;
     }
 
     // ----------------------------------------------

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -186,6 +186,12 @@ public abstract class ComposeFileSystem : FileSystem
         FallbackSafe.SetLastWriteTime(ConvertPathToDelegate(path), time);
     }
 
+    /// <inheritdoc />
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        FallbackSafe.CreateSymbolicLink(ConvertPathToDelegate(path), ConvertPathToDelegate(pathToTarget));
+    }
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -575,6 +575,7 @@ public abstract class FileSystem : IFileSystem
         if (systemPath is null) throw new ArgumentNullException(nameof(systemPath));
         return ValidatePath(ConvertPathFromInternalImpl(systemPath));
     }
+
     /// <summary>
     /// Implementation for <see cref="ConvertPathToInternal"/>, <paramref name="innerPath"/> is guaranteed to be not null and return path to be validated through <see cref="ValidatePath"/>.
     /// Converts the specified system path to a <see cref="IFileSystem"/> path.

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -447,17 +447,18 @@ public abstract class FileSystem : IFileSystem
 
 
     /// <inheritdoc />
-    public UPath? ResolveLinkTarget(UPath linkPath)
+    public bool TryResolveLinkTarget(UPath linkPath, out UPath resolvedPath)
     {
         AssertNotDisposed();
-        return ResolveLinkTargetImpl(ValidatePath(linkPath));
+        return TryResolveLinkTargetImpl(ValidatePath(linkPath), out resolvedPath);
     }
 
     /// <summary>
     /// Resolves the target of a symbolic link.
     /// </summary>
     /// <param name="linkPath">The path of the symbolic link to resolve.</param>
-    protected abstract UPath? ResolveLinkTargetImpl(UPath linkPath);
+    /// <param name="resolvedPath"></param>
+    protected abstract bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath);
 
     // ----------------------------------------------
     // Search API

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -431,6 +431,20 @@ public abstract class FileSystem : IFileSystem
     /// <param name="time">A <see cref="DateTime"/> containing the value to set for the last write date and time of path. This value is expressed in local time.</param>
     protected abstract void SetLastWriteTimeImpl(UPath path, DateTime time);
 
+    /// <inheritdoc />
+    public void CreateSymbolicLink(UPath path, UPath pathToTarget)
+    {
+        AssertNotDisposed();
+        CreateSymbolicLinkImpl(ValidatePath(path), ValidatePath(pathToTarget));
+    }
+
+    /// <summary>
+    /// Creates a symbolic link.
+    /// </summary>
+    /// <param name="path">The path of the symbolic link to create.</param>
+    /// <param name="pathToTarget">The path of the target for the symbolic link.</param>
+    protected abstract void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget);
+    
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -444,7 +444,21 @@ public abstract class FileSystem : IFileSystem
     /// <param name="path">The path of the symbolic link to create.</param>
     /// <param name="pathToTarget">The path of the target for the symbolic link.</param>
     protected abstract void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget);
-    
+
+
+    /// <inheritdoc />
+    public UPath? ResolveLinkTarget(UPath linkPath)
+    {
+        AssertNotDisposed();
+        return ResolveLinkTargetImpl(ValidatePath(linkPath));
+    }
+
+    /// <summary>
+    /// Resolves the target of a symbolic link.
+    /// </summary>
+    /// <param name="linkPath">The path of the symbolic link to resolve.</param>
+    protected abstract UPath? ResolveLinkTargetImpl(UPath linkPath);
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/MemoryFileSystem.cs
+++ b/src/Zio/FileSystems/MemoryFileSystem.cs
@@ -759,6 +759,12 @@ public class MemoryFileSystem : FileSystem
         throw new NotSupportedException("Symbolic links are not supported by MemoryFileSystem");
     }
 
+    /// <inheritdoc />
+    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    {
+        return null;
+    }
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/MemoryFileSystem.cs
+++ b/src/Zio/FileSystems/MemoryFileSystem.cs
@@ -760,9 +760,10 @@ public class MemoryFileSystem : FileSystem
     }
 
     /// <inheritdoc />
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
-        return null;
+        resolvedPath = default;
+        return false;
     }
 
     // ----------------------------------------------

--- a/src/Zio/FileSystems/MemoryFileSystem.cs
+++ b/src/Zio/FileSystems/MemoryFileSystem.cs
@@ -753,6 +753,12 @@ public class MemoryFileSystem : FileSystem
         TryGetDispatcher()?.RaiseChange(path);
     }
 
+    /// <inheritdoc />
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        throw new NotSupportedException("Symbolic links are not supported by MemoryFileSystem");
+    }
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -566,6 +566,15 @@ public class MountFileSystem : ComposeFileSystem
     }
 
     /// <inheritdoc />
+    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    {
+        var mountfs = TryGetMountOrNext(ref linkPath, out var mountPath);
+        var path = mountfs?.ResolveLinkTarget(linkPath);
+
+        return path != null ? CombinePrefix(mountPath, path.Value) : default(UPath?);
+    }
+
+    /// <inheritdoc />
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     {
         // Use the search pattern to normalize the path/search pattern

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -566,12 +566,24 @@ public class MountFileSystem : ComposeFileSystem
     }
 
     /// <inheritdoc />
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
         var mountfs = TryGetMountOrNext(ref linkPath, out var mountPath);
-        var path = mountfs?.ResolveLinkTarget(linkPath);
 
-        return path != null ? CombinePrefix(mountPath, path.Value) : default(UPath?);
+        if (mountfs is null)
+        {
+            resolvedPath = default;
+            return false;
+        }
+
+        if (!mountfs.TryResolveLinkTarget(linkPath, out var resolved))
+        {
+            resolvedPath = default;
+            return false;
+        }
+
+        resolvedPath = CombinePrefix(mountPath, resolved);
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -551,6 +551,21 @@ public class MountFileSystem : ComposeFileSystem
     }
 
     /// <inheritdoc />
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        var originalSrcPath = path;
+        var mountfs = TryGetMountOrNext(ref path);
+        if (mountfs != null)
+        {
+            mountfs.CreateSymbolicLink(path, pathToTarget);
+        }
+        else
+        {
+            throw NewFileNotFoundException(originalSrcPath);
+        }
+    }
+
+    /// <inheritdoc />
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     {
         // Use the search pattern to normalize the path/search pattern

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -555,6 +555,13 @@ public class MountFileSystem : ComposeFileSystem
     {
         var originalSrcPath = path;
         var mountfs = TryGetMountOrNext(ref path);
+        var mountTargetfs = TryGetMountOrNext(ref pathToTarget);
+
+        if (mountfs != mountTargetfs)
+        {
+            throw new InvalidOperationException("Cannot create a symbolic link between two different filesystems");
+        }
+
         if (mountfs != null)
         {
             mountfs.CreateSymbolicLink(path, pathToTarget);
@@ -967,6 +974,19 @@ public class MountFileSystem : ComposeFileSystem
     protected override UPath ConvertPathFromDelegate(UPath path)
     {
         return path;
+    }
+
+    protected override string ConvertPathToInternalImpl(UPath path)
+    {
+        var mountPath = path;
+        var mountfs = TryGetMountOrNext(ref mountPath);
+
+        if (mountfs != null)
+        {
+            return mountfs.ConvertPathToInternal(mountPath);
+        }
+
+        return base.ConvertPathToInternalImpl(path);
     }
 
     private IFileSystem? TryGetMountOrNext(ref UPath path)

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -976,19 +976,6 @@ public class MountFileSystem : ComposeFileSystem
         return path;
     }
 
-    protected override string ConvertPathToInternalImpl(UPath path)
-    {
-        var mountPath = path;
-        var mountfs = TryGetMountOrNext(ref mountPath);
-
-        if (mountfs != null)
-        {
-            return mountfs.ConvertPathToInternal(mountPath);
-        }
-
-        return base.ConvertPathToInternalImpl(path);
-    }
-
     private IFileSystem? TryGetMountOrNext(ref UPath path)
     {
         return TryGetMountOrNext(ref path, out var _);

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -516,7 +516,7 @@ public class PhysicalFileSystem : FileSystem
     }
 
     /// <inheritdoc />
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
         if (IsWithinSpecialDirectory(linkPath))
         {
@@ -536,7 +536,8 @@ public class PhysicalFileSystem : FileSystem
         }
         else
         {
-            return null;
+            resolvedPath = default;
+            return false;
         }
 
 #if NET7_0_OR_GREATER
@@ -545,7 +546,14 @@ public class PhysicalFileSystem : FileSystem
         var systemResult = IsOnWindows ? Interop.Windows.GetFinalPathName(systemPath) : Interop.Unix.readlink(systemPath);
 #endif
 
-        return systemResult != null ? ConvertPathFromInternal(systemResult) : default(UPath?);
+        if (systemResult == null)
+        {
+            resolvedPath = default;
+            return false;
+        }
+
+        resolvedPath = ConvertPathFromInternal(systemResult);
+        return true;
     }
 
     // ----------------------------------------------

--- a/src/Zio/FileSystems/ReadOnlyFileSystem.cs
+++ b/src/Zio/FileSystems/ReadOnlyFileSystem.cs
@@ -129,6 +129,12 @@ public class ReadOnlyFileSystem : ComposeFileSystem
         throw new IOException(FileSystemIsReadOnly);
     }
 
+    /// <inheritdoc />
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        throw new IOException(FileSystemIsReadOnly);
+    }
+
     // ----------------------------------------------
     // Path
     // ----------------------------------------------

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -824,6 +824,12 @@ public class ZipArchiveFileSystem : FileSystem
     }
 
     /// <inheritdoc />
+    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    {
+        return null;
+    }
+
+    /// <inheritdoc />
     protected override IFileSystemWatcher WatchImpl(UPath path)
     {
         var watcher = new FileSystemWatcher(this, path);

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -818,6 +818,12 @@ public class ZipArchiveFileSystem : FileSystem
     }
 
     /// <inheritdoc />
+    protected override void CreateSymbolicLinkImpl(UPath path, UPath pathToTarget)
+    {
+        throw new NotSupportedException("Symbolic links are not supported by ZipArchiveFileSystem");
+    }
+
+    /// <inheritdoc />
     protected override IFileSystemWatcher WatchImpl(UPath path)
     {
         var watcher = new FileSystemWatcher(this, path);

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -824,9 +824,10 @@ public class ZipArchiveFileSystem : FileSystem
     }
 
     /// <inheritdoc />
-    protected override UPath? ResolveLinkTargetImpl(UPath linkPath)
+    protected override bool TryResolveLinkTargetImpl(UPath linkPath, out UPath resolvedPath)
     {
-        return null;
+        resolvedPath = UPath.Empty;
+        return false;
     }
 
     /// <inheritdoc />

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -174,7 +174,8 @@ public interface IFileSystem : IDisposable
     /// Resolves the target of a symbolic link.
     /// </summary>
     /// <param name="linkPath">The path of the symbolic link to resolve.</param>
-    UPath? ResolveLinkTarget(UPath linkPath);
+    /// <param name="resolvedPath">The path of the symbolic link resolved if true is returned.</param>
+    bool TryResolveLinkTarget(UPath linkPath, out UPath resolvedPath);
 
     // ----------------------------------------------
     // Search API

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -163,6 +163,13 @@ public interface IFileSystem : IDisposable
     /// <param name="time">A <see cref="DateTime"/> containing the value to set for the last write date and time of path. This value is expressed in local time.</param>
     void SetLastWriteTime(UPath path, DateTime time);
 
+    /// <summary>
+    /// Creates a symbolic link.
+    /// </summary>
+    /// <param name="path">The path of the symbolic link to create.</param>
+    /// <param name="pathToTarget">The path of the target for the symbolic link.</param>
+    void CreateSymbolicLink(UPath path, UPath pathToTarget);
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -170,6 +170,12 @@ public interface IFileSystem : IDisposable
     /// <param name="pathToTarget">The path of the target for the symbolic link.</param>
     void CreateSymbolicLink(UPath path, UPath pathToTarget);
 
+    /// <summary>
+    /// Resolves the target of a symbolic link.
+    /// </summary>
+    /// <param name="linkPath">The path of the symbolic link to resolve.</param>
+    UPath? ResolveLinkTarget(UPath linkPath);
+
     // ----------------------------------------------
     // Search API
     // ----------------------------------------------

--- a/src/Zio/Interop.cs
+++ b/src/Zio/Interop.cs
@@ -3,7 +3,10 @@
 // See the license.txt file in the project root for more information.
 
 #if !NET7_0_OR_GREATER
+using System.ComponentModel;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Zio;
 
@@ -11,8 +14,77 @@ internal static class Interop
 {
     public static class Windows
     {
+        private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+        private const uint FILE_READ_EA = 0x0008;
+        private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
+
+        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern uint GetFinalPathNameByHandle(IntPtr hFile, [MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr CreateFile(
+            [MarshalAs(UnmanagedType.LPTStr)] string filename,
+            [MarshalAs(UnmanagedType.U4)] uint access,
+            [MarshalAs(UnmanagedType.U4)] FileShare share,
+            IntPtr securityAttributes,
+            [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+            [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
+            IntPtr templateFile);
+
+        public static string GetFinalPathName(string path)
+        {
+            var h = CreateFile(path,
+                FILE_READ_EA,
+                FileShare.ReadWrite | FileShare.Delete,
+                IntPtr.Zero,
+                FileMode.Open,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+
+            if (h == INVALID_HANDLE_VALUE)
+            {
+                throw new Win32Exception();
+            }
+
+            try
+            {
+                var sb = new StringBuilder(1024);
+                var res = GetFinalPathNameByHandle(h, sb, 1024, 0);
+                if (res == 0)
+                {
+                    throw new Win32Exception();
+                }
+
+                // Trim '\\?\'
+                if (sb.Length >= 4 && sb[0] == '\\' && sb[1] == '\\' && sb[2] == '?' && sb[3] == '\\')
+                {
+                    sb.Remove(0, 4);
+
+                    // Trim 'UNC\'
+                    if (sb.Length >= 4 && sb[0] == 'U' && sb[1] == 'N' && sb[2] == 'C' && sb[3] == '\\')
+                    {
+                        sb.Remove(0, 4);
+
+                        // Add the default UNC prefix
+                        sb.Insert(0, @"\\");
+                    }
+                }
+
+                return sb.ToString();
+            }
+            finally
+            {
+                CloseHandle(h);
+            }
+        }
 
         public enum SymbolicLink
         {
@@ -25,6 +97,17 @@ internal static class Interop
     {
         [DllImport("libc", SetLastError = true)]
         public static extern int symlink(string target, string linkpath);
+
+        [DllImport ("libc")]
+        private static extern int readlink (string path, byte[] buffer, int buflen);
+
+        public static string? readlink(string path)
+        {
+            var buf = new byte[1024];
+            var ret = readlink(path, buf, buf.Length);
+
+            return ret == -1 ? null : Encoding.Default.GetString(buf, 0, ret);
+        }
     }
 }
 #endif

--- a/src/Zio/Interop.cs
+++ b/src/Zio/Interop.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if !NET7_0_OR_GREATER
+using System.Runtime.InteropServices;
+
+namespace Zio;
+
+internal static class Interop
+{
+    public static class Windows
+    {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
+
+        public enum SymbolicLink
+        {
+            File = 0,
+            Directory = 1
+        }
+    }
+
+    public static class Unix
+    {
+        [DllImport("libc", SetLastError = true)]
+        public static extern int symlink(string target, string linkpath);
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #74 

This PR implements `IFileSystem.CreateSymbolicLink(UPath path, UPath pathToTarget)`

# Linux
OS: Ubuntu 20.04 focal
Kernel: x86_64 Linux 5.10.102.1-microsoft-standard-WSL2

```
$ dotnet test -f net8.0 --filter Symlink
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 4 ms - Zio.Tests.dll (net8.0)
```

After adding .NET 6.0 to the targets (to validate the .NET Standard 2.1 implementation):
```
$ dotnet test -f net6.0 --filter Symlink
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 3 ms - Zio.Tests.dll (net6.0)
```

# Windows
OS: Windows 11 23H2
Note: needs to be tested with administrator rights

```
$ dotnet test -f net8.0 --filter Symlink
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 19 ms - Zio.Tests.dll (net8.0)

$ dotnet test -f net472 --filter Symlink
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 25 ms - Zio.Tests.dll (net472)
```