### PR TITLE
Fix SubFileSystem watcher (sometimes) silently discarding events

### DIFF
--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -93,13 +93,13 @@ public class TestSubFileSystem : TestFileSystemBase
 
         var subFs = new SubFileSystem(physicalFs, subDir);
         var watcher = subFs.Watch("/");
+        var waitHandle = new ManualResetEvent(false);
 
-        var gotChange = false;
         watcher.Created += (sender, args) =>
         {
             if (args.FullPath == filePath)
             {
-                gotChange = true;
+                waitHandle.Set();
             }
         };
 
@@ -107,8 +107,8 @@ public class TestSubFileSystem : TestFileSystemBase
         watcher.EnableRaisingEvents = true;
 
         physicalFs.WriteAllText($"{physicalDir}{filePath}", "test");
-        Thread.Sleep(100);
-        Assert.True(gotChange);
+
+        Assert.True(waitHandle.WaitOne(100));
     }
 
     [SkippableFact]

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -74,6 +74,43 @@ public class TestSubFileSystem : TestFileSystemBase
         Assert.True(gotChange);
     }
 
+    [SkippableTheory]
+    [InlineData("/test", "/test", "/foo.txt")]
+    [InlineData("/test", "/test", "/~foo.txt")]
+    [InlineData("/test", "/TEST", "/foo.txt")]
+    [InlineData("/test", "/TEST", "/~foo.txt")]
+    [InlineData("/verylongname", "/VERYLONGNAME", "/foo.txt")]
+    [InlineData("/verylongname", "/VERYLONGNAME", "/~foo.txt")]
+    public void TestWatcherCaseSensitive(string physicalDir, string subDir, string filePath)
+    {
+        Skip.IfNot(IsWindows, "This test involves case insensitivity on Windows");
+
+        var physicalFs = GetCommonPhysicalFileSystem();
+        physicalFs.CreateDirectory(physicalDir);
+
+        Assert.True(physicalFs.DirectoryExists(physicalDir));
+        Assert.True(physicalFs.DirectoryExists(subDir));
+
+        var subFs = new SubFileSystem(physicalFs, subDir);
+        var watcher = subFs.Watch("/");
+
+        var gotChange = false;
+        watcher.Created += (sender, args) =>
+        {
+            if (args.FullPath == filePath)
+            {
+                gotChange = true;
+            }
+        };
+
+        watcher.IncludeSubdirectories = true;
+        watcher.EnableRaisingEvents = true;
+
+        physicalFs.WriteAllText($"{physicalDir}{filePath}", "test");
+        Thread.Sleep(100);
+        Assert.True(gotChange);
+    }
+
     [SkippableFact]
     public void TestDirectorySymlink()
     {

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -977,7 +977,7 @@ public class PhysicalFileSystem : FileSystem
             if (innerPath.StartsWith(@"\\", StringComparison.Ordinal) || innerPath.StartsWith(@"\?", StringComparison.Ordinal))
                 throw new NotSupportedException($"Path starting with `\\\\` or `\\?` are not supported -> `{innerPath}` ");
 
-            var absolutePath = Path.GetFullPath(innerPath);
+            var absolutePath = Path.IsPathRooted(innerPath) ? innerPath : Path.GetFullPath(innerPath);
             var driveIndex = absolutePath.IndexOf(":\\", StringComparison.Ordinal);
             if (driveIndex != 1)
                 throw new ArgumentException($"Expecting a drive for the path `{absolutePath}`");


### PR DESCRIPTION
Fixes #91 by only calling _Path.GetFullPath_ for non-rooted paths on Windows in _PhysicalFileSystem.ConvertPathFromInternalImpl_.

Paths from filesystem events are already rooted, so this skips the weird behaviour for paths containing a `~`.