### PR TITLE
Optimize cross-filesystem operations

### DIFF
--- a/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using Zio.FileSystems;
@@ -36,10 +36,10 @@ public class TestMemoryFileSystem : TestFileSystemBase
         fs.CopyTo(dest, subFolder, true);
 
         var destSubFileSystem = dest.GetOrCreateSubFileSystem(subFolder);
-        
+
         AssertFileSystemEqual(fs, destSubFileSystem);
     }
-    
+
 
     [Fact]
     public void TestWatcher()
@@ -79,5 +79,58 @@ public class TestMemoryFileSystem : TestFileSystemBase
 
         memfs.Dispose();
         Assert.Throws<ObjectDisposedException>(() => memfs.DirectoryExists("/"));
+    }
+
+    [Fact]
+    public void TestCopyFileCross()
+    {
+        var fs = new TriggerMemoryFileSystem();
+        fs.CreateDirectory("/sub1");
+        fs.CreateDirectory("/sub2");
+        var sub1 = new SubFileSystem(fs, "/sub1");
+        var sub2 = new SubFileSystem(fs, "/sub2");
+        sub1.WriteAllText("/file.txt", "test");
+        sub1.CopyFileCross("/file.txt", sub2, "/file.txt", overwrite: false);
+        Assert.Equal("test", sub2.ReadAllText("/file.txt"));
+        Assert.Equal(TriggerMemoryFileSystem.TriggerType.Copy, fs.Triggered);
+    }
+
+    [Fact]
+    public void TestMoveFileCross()
+    {
+        var fs = new TriggerMemoryFileSystem();
+        fs.CreateDirectory("/sub1");
+        fs.CreateDirectory("/sub2");
+        var sub1 = new SubFileSystem(fs, "/sub1");
+        var sub2 = new SubFileSystem(fs, "/sub2");
+        sub1.WriteAllText("/file.txt", "test");
+        sub1.MoveFileCross("/file.txt", sub2, "/file.txt");
+        Assert.Equal("test", sub2.ReadAllText("/file.txt"));
+        Assert.False(sub1.FileExists("/file.txt"));
+        Assert.Equal(TriggerMemoryFileSystem.TriggerType.Move, fs.Triggered);
+    }
+
+    private sealed class TriggerMemoryFileSystem : MemoryFileSystem
+    {
+        public enum TriggerType
+        {
+            None,
+            Copy,
+            Move
+        }
+
+        public TriggerType Triggered { get; private set; } = TriggerType.None;
+
+        protected override void CopyFileImpl(UPath srcPath, UPath destPath, bool overwrite)
+        {
+            Triggered = TriggerType.Copy;
+            base.CopyFileImpl(srcPath, destPath, overwrite);
+        }
+
+        protected override void MoveFileImpl(UPath srcPath, UPath destPath)
+        {
+            Triggered = TriggerType.Move;
+            base.MoveFileImpl(srcPath, destPath);
+        }
     }
 }

--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.IO;
@@ -352,7 +352,7 @@ public class TestPhysicalFileSystem : TestFileSystemBase
         var expectedPaths = Directory.EnumerateFileSystemEntries(Path.GetFullPath(Path.Combine(SystemPath, "../.."))).ToList();
         Assert.Equal(expectedPaths, paths);
     }
-    
+
     [SkippableFact]
     public void TestFileWindowsExceptions()
     {
@@ -551,5 +551,15 @@ public class TestPhysicalFileSystem : TestFileSystemBase
             SafeDeleteFile(systemPathSource);
             SafeDeleteFile(systemPathDest);
         }
+    }
+
+    [Fact]
+    public void TestResolvePath()
+    {
+        var fs = new PhysicalFileSystem();
+        var testPath = fs.ConvertPathFromInternal(SystemPath);
+        var (resFs, resPath) = fs.ResolvePath(testPath);
+        Assert.Equal(testPath, resPath);
+        Assert.Equal(fs, resFs);
     }
 }

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.IO;
@@ -36,7 +36,7 @@ public class TestSubFileSystem : TestFileSystemBase
         }
 
         // TODO: We could add another test just to make sure that files can be created...etc. But the test above should already cover the code provided in SubFileSystem
-    } 
+    }
 
     [Fact]
     public void TestGetOrCreateFileSystem()
@@ -72,6 +72,27 @@ public class TestSubFileSystem : TestFileSystemBase
         fs.WriteAllText("/a/b/watched.txt", "test");
         System.Threading.Thread.Sleep(100);
         Assert.True(gotChange);
+    }
+
+    [Fact]
+    public void TestResolvePath()
+    {
+        var fs = GetCommonMemoryFileSystem();
+        var subFs = fs.GetOrCreateSubFileSystem("/a/b");
+        var (resFs, resPath) = subFs.ResolvePath("/c");
+        Assert.Equal("/a/b/c", resPath);
+        Assert.NotEqual(subFs, resFs);
+        Assert.Equal(fs, resFs);
+        (resFs, resPath) = subFs.ResolvePath("/c/d");
+        Assert.Equal("/a/b/c/d", resPath);
+        Assert.NotEqual(subFs, resFs);
+        Assert.Equal(fs, resFs);
+
+        var subFs2 = subFs.GetOrCreateSubFileSystem("/q");
+        (resFs, resPath) = subFs2.ResolvePath("/c");
+        Assert.Equal("/a/b/q/c", resPath);
+        Assert.NotEqual(subFs2, resFs);
+        Assert.Equal(fs, resFs);
     }
 
     [SkippableFact]

--- a/src/Zio.Tests/Zio.Tests.csproj
+++ b/src/Zio.Tests/Zio.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/src/Zio/FileSystemExtensions.cs
+++ b/src/Zio/FileSystemExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.IO;
@@ -149,6 +149,9 @@ public static class FileSystemExtensions
     {
         if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
 
+        (fs, srcPath) = fs.ResolvePath(srcPath);
+        (destFileSystem, destPath) = destFileSystem.ResolvePath(destPath);
+
         // If this is the same filesystem, use the file system directly to perform the action
         if (fs == destFileSystem)
         {
@@ -223,6 +226,9 @@ public static class FileSystemExtensions
     public static void MoveFileCross(this IFileSystem fs, UPath srcPath, IFileSystem destFileSystem, UPath destPath)
     {
         if (destFileSystem is null) throw new ArgumentNullException(nameof(destFileSystem));
+
+        (fs, srcPath) = fs.ResolvePath(srcPath);
+        (destFileSystem, destPath) = destFileSystem.ResolvePath(destPath);
 
         // If this is the same filesystem, use the file system directly to perform the action
         if (fs == destFileSystem)
@@ -340,11 +346,11 @@ public static class FileSystemExtensions
     public static string ReadAllText(this IFileSystem fs, UPath path)
     {
         var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        
+
         using (var reader = new StreamReader(stream))
         {
             return reader.ReadToEnd();
-        }        
+        }
     }
 
     /// <summary>
@@ -358,7 +364,7 @@ public static class FileSystemExtensions
     {
         if (encoding is null) throw new ArgumentNullException(nameof(encoding));
         var stream = fs.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        
+
         using (var reader = new StreamReader(stream, encoding))
         {
             return reader.ReadToEnd();
@@ -576,7 +582,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by path.</returns>
     public static IEnumerable<UPath> EnumerateDirectories(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -590,9 +596,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by path.</returns>
@@ -618,7 +624,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the files in the directory specified by path.</returns>
     public static IEnumerable<UPath> EnumerateFiles(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -632,9 +638,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the files in the directory specified by path.</returns>
@@ -660,7 +666,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files or directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the files and directories in the directory specified by path.</returns>
     public static IEnumerable<UPath> EnumeratePaths(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -674,9 +680,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files or directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <returns>An enumerable collection of the full names (including paths) for the files and directories in the directory specified by path.</returns>
@@ -702,7 +708,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of <see cref="FileEntry"/> from the specified path.</returns>
     public static IEnumerable<FileEntry> EnumerateFileEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -716,9 +722,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <returns>An enumerable collection of <see cref="FileEntry"/> from the specified path.</returns>
@@ -747,7 +753,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of <see cref="DirectoryEntry"/> from the specified path.</returns>
     public static IEnumerable<DirectoryEntry> EnumerateDirectoryEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -761,9 +767,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <returns>An enumerable collection of <see cref="DirectoryEntry"/> from the specified path.</returns>
@@ -792,7 +798,7 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files and directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
     /// <returns>An enumerable collection of <see cref="FileSystemEntry"/> that match a search pattern in a specified path.</returns>
     public static IEnumerable<FileSystemEntry> EnumerateFileSystemEntries(this IFileSystem fileSystem, UPath path, string searchPattern)
@@ -806,9 +812,9 @@ public static class FileSystemExtensions
     /// </summary>
     /// <param name="fileSystem">The file system.</param>
     /// <param name="path">The path of the directory to look for files and directories.</param>
-    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination 
+    /// <param name="searchPattern">The search string to match against the names of directories in path. This parameter can contain a combination
     /// of valid literal path and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions.</param>
-    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory 
+    /// <param name="searchOption">One of the enumeration values that specifies whether the search operation should include only the current directory
     /// or should include all subdirectories.
     /// The default value is TopDirectoryOnly.</param>
     /// <param name="searchTarget">The search target either <see cref="SearchTarget.Both"/> or only <see cref="SearchTarget.Directory"/> or <see cref="SearchTarget.File"/>. Default is <see cref="SearchTarget.Both"/></param>

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 using System.Diagnostics;
 using System.IO;
@@ -7,7 +7,7 @@ using System.IO;
 namespace Zio.FileSystems;
 
 /// <summary>
-/// Provides an abstract base <see cref="IFileSystem"/> for composing a filesystem with another FileSystem. 
+/// Provides an abstract base <see cref="IFileSystem"/> for composing a filesystem with another FileSystem.
 /// This implementation delegates by default its implementation to the filesystem passed to the constructor.
 /// </summary>
 public abstract class ComposeFileSystem : FileSystem
@@ -274,4 +274,7 @@ public abstract class ComposeFileSystem : FileSystem
     /// <param name="path">The path used by the underlying <see cref="Fallback"/></param>
     /// <returns>A new path translated to this filesystem</returns>
     protected abstract UPath ConvertPathFromDelegate(UPath path);
+
+    protected override (IFileSystem FileSystem, UPath Path) ResolvePathImpl(UPath path)
+        => FallbackSafe.ResolvePath(ConvertPathToDelegate(path));
 }

--- a/src/Zio/FileSystems/FileSystem.cs
+++ b/src/Zio/FileSystems/FileSystem.cs
@@ -584,6 +584,25 @@ public abstract class FileSystem : IFileSystem
     /// <returns>The converted path according to the system path.</returns>
     protected abstract UPath ConvertPathFromInternalImpl(string innerPath);
 
+    /// <inheritdoc />
+    public (IFileSystem FileSystem, UPath Path) ResolvePath(UPath path)
+    {
+        AssertNotDisposed();
+        return ResolvePathImpl(ValidatePath(path));
+    }
+
+    /// <summary>
+    /// Implementation for <see cref="ResolvePath" />.
+    /// Resolves the specified path to a path in the underlying file system, if one exists. For instance, a <see cref="Zio.FileSystems.SubFileSystem"/> would
+    /// resolve the path to a qualified path in the underlying file system.
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>
+    /// A tuple of the resolved path and file system. If there is no underlying file
+    /// system, the returned path is the same, and the file system is the same.
+    /// </returns>
+    protected virtual (IFileSystem FileSystem, UPath Path) ResolvePathImpl(UPath path) => (this, path);
+
     /// <summary>
     /// User overridable implementation for <see cref="ValidatePath"/> to validate the specified path.
     /// </summary>

--- a/src/Zio/IFileSystem.cs
+++ b/src/Zio/IFileSystem.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.IO;
@@ -36,7 +36,7 @@ public interface IFileSystem : IDisposable
     void MoveDirectory(UPath srcPath, UPath destPath);
 
     /// <summary>
-    /// Deletes the specified directory and, if indicated, any subdirectories and files in the directory. 
+    /// Deletes the specified directory and, if indicated, any subdirectories and files in the directory.
     /// </summary>
     /// <param name="path">The path of the directory to remove.</param>
     /// <param name="isRecursive"><c>true</c> to remove directories, subdirectories, and files in path; otherwise, <c>false</c>.</param>
@@ -74,9 +74,9 @@ public interface IFileSystem : IDisposable
     /// Determines whether the specified file exists.
     /// </summary>
     /// <param name="path">The path.</param>
-    /// <returns><c>true</c> if the caller has the required permissions and path contains the name of an existing file; 
-    /// otherwise, <c>false</c>. This method also returns false if path is null, an invalid path, or a zero-length string. 
-    /// If the caller does not have sufficient permissions to read the specified file, 
+    /// <returns><c>true</c> if the caller has the required permissions and path contains the name of an existing file;
+    /// otherwise, <c>false</c>. This method also returns false if path is null, an invalid path, or a zero-length string.
+    /// If the caller does not have sufficient permissions to read the specified file,
     /// no exception is thrown and the method returns false regardless of the existence of path.</returns>
     bool FileExists(UPath path);
 
@@ -88,7 +88,7 @@ public interface IFileSystem : IDisposable
     void MoveFile(UPath srcPath, UPath destPath);
 
     /// <summary>
-    /// Deletes the specified file. 
+    /// Deletes the specified file.
     /// </summary>
     /// <param name="path">The path of the file to be deleted.</param>
     void DeleteFile(UPath path);
@@ -224,7 +224,7 @@ public interface IFileSystem : IDisposable
     // ----------------------------------------------
 
     /// <summary>
-    /// Converts the specified path to the underlying path used by this <see cref="IFileSystem"/>. In case of a <see cref="Zio.FileSystems.PhysicalFileSystem"/>, it 
+    /// Converts the specified path to the underlying path used by this <see cref="IFileSystem"/>. In case of a <see cref="Zio.FileSystems.PhysicalFileSystem"/>, it
     /// would represent the actual path on the disk.
     /// </summary>
     /// <param name="path">The path.</param>
@@ -237,10 +237,21 @@ public interface IFileSystem : IDisposable
     /// <param name="systemPath">The system path.</param>
     /// <returns>The converted path according to the system path.</returns>
     UPath ConvertPathFromInternal(string systemPath);
+
+    /// <summary>
+    /// Resolves the specified path to a path in the underlying file system, if one exists. For instance, a <see cref="Zio.FileSystems.SubFileSystem"/> would
+    /// resolve the path to a qualified path in the underlying file system.
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>
+    /// A tuple of the resolved path and file system. If there is no underlying file
+    /// system, the returned path is the same, and the file system is the same.
+    /// </returns>
+    (IFileSystem FileSystem, UPath Path) ResolvePath(UPath path);
 }
 
 /// <summary>
-/// Used by <see cref="IFileSystem.EnumerateItems"/>. 
+/// Used by <see cref="IFileSystem.EnumerateItems"/>.
 /// </summary>
 /// <param name="item">The file system item to filer.</param>
 /// <returns><c>true</c> if the item should be kept; otherwise <c>false</c>.</returns>

--- a/src/Zio/Zio.csproj
+++ b/src/Zio/Zio.csproj
@@ -30,13 +30,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
@@ -45,7 +48,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
@@ -54,7 +57,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
-  
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE</DefineConstants>
   </PropertyGroup>
@@ -72,7 +75,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE;HAS_NULLABLEANNOTATIONS</DefineConstants>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>$(AdditionalConstants);HAS_ZIPARCHIVE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Adds a new function to  that resolves a path through all underlying filesystems. Allows cross-file system operations to resolve to the final FS and call operations directly on that file system.

Fixes #90 