### PR TITLE
Fix cross-filesystem operations in MountFileSystem

### DIFF
--- a/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs
@@ -93,6 +93,23 @@ public class TestMemoryFileSystem : TestFileSystemBase
         Assert.Equal(TriggerMemoryFileSystem.TriggerType.Move, fs.Triggered);
     }
 
+    [Fact]
+    public void TestMoveFileCrossMount()
+    {
+        var fs = new TriggerMemoryFileSystem();
+        fs.CreateDirectory("/sub1");
+        fs.CreateDirectory("/sub2");
+        var mount = new MountFileSystem();
+        var sub1 = new SubFileSystem(fs, "/sub1");
+        var sub2 = new SubFileSystem(fs, "/sub2");
+        mount.Mount("/sub2-mount", sub2);
+        sub1.WriteAllText("/file.txt", "test");
+        sub1.MoveFileCross("/file.txt", mount, "/sub2-mount/file.txt");
+        Assert.Equal("test", sub2.ReadAllText("/file.txt"));
+        Assert.False(sub1.FileExists("/file.txt"));
+        Assert.Equal(TriggerMemoryFileSystem.TriggerType.Move, fs.Triggered);
+    }
+
     private sealed class TriggerMemoryFileSystem : MemoryFileSystem
     {
         public enum TriggerType

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -276,5 +276,5 @@ public abstract class ComposeFileSystem : FileSystem
     protected abstract UPath ConvertPathFromDelegate(UPath path);
 
     protected override (IFileSystem FileSystem, UPath Path) ResolvePathImpl(UPath path)
-        => Fallback?.ResolvePath(ConvertPathToDelegate(path)) ?? (this, path);
+        => Fallback?.ResolvePath(ConvertPathToDelegate(path)) ?? base.ResolvePathImpl(path);
 }

--- a/src/Zio/FileSystems/ComposeFileSystem.cs
+++ b/src/Zio/FileSystems/ComposeFileSystem.cs
@@ -276,5 +276,5 @@ public abstract class ComposeFileSystem : FileSystem
     protected abstract UPath ConvertPathFromDelegate(UPath path);
 
     protected override (IFileSystem FileSystem, UPath Path) ResolvePathImpl(UPath path)
-        => FallbackSafe.ResolvePath(ConvertPathToDelegate(path));
+        => Fallback?.ResolvePath(ConvertPathToDelegate(path)) ?? (this, path);
 }

--- a/src/Zio/FileSystems/MountFileSystem.cs
+++ b/src/Zio/FileSystems/MountFileSystem.cs
@@ -594,6 +594,19 @@ public class MountFileSystem : ComposeFileSystem
     }
 
     /// <inheritdoc />
+    protected override (IFileSystem FileSystem, UPath Path) ResolvePathImpl(UPath path)
+    {
+        var mountfs = TryGetMountOrNext(ref path);
+
+        if (mountfs is null)
+        {
+            return base.ResolvePathImpl(path);
+        }
+
+        return mountfs.ResolvePath(path);
+    }
+
+    /// <inheritdoc />
     protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     {
         // Use the search pattern to normalize the path/search pattern


### PR DESCRIPTION
While looking at #94, I saw a possible issue with MountFileSystem. It's possible for the MountFileSystem to not have a fallback filesystem, causing `ResolvePath` to throw an InvalidOperationException. The change in ComposeFileSystem fixes this problem.

After that I've implemented `ResolvePathImpl` in MountFileSystem, so it'll also use the move when the `MountFileSystem` isn't used directly, e.g.:
https://github.com/xoofx/zio/blob/574a76d5e58434db98d7743f05fb9149e5a68f27/src/Zio.Tests/FileSystems/TestMemoryFileSystem.cs#L107