### PR TITLE
Fix rooted path without volume label regression on Windows

### DIFF
--- a/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestPhysicalFileSystem.cs
@@ -31,6 +31,19 @@ public class TestPhysicalFileSystem : TestFileSystemBase
         }
     }
 
+    [SkippableFact]
+    public void TestRootedPathWithoutDriveOnWindows()
+    {
+        Skip.IfNot(IsWindows, "Testing Windows-specific behavior");
+
+        var driveLetter = Directory.GetCurrentDirectory()[0];
+        var fs = new PhysicalFileSystem();
+
+        var resolvedPath = fs.ConvertPathFromInternal("/test");
+
+        Assert.Equal($"/mnt/{driveLetter}/test", resolvedPath.ToString(), StringComparer.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void TestWatcher()
     {


### PR DESCRIPTION
On Windows, PhysicalFileSystem.ConvertPathFromInternalImpl requires a volume label after resolving an absolute path. My fix for #91 meant that rooted paths without a volume label, like `/example`, wouldn't be resolved to include such a label.

This PR fixes that by explicitly checking for a volume label before deciding to use Path.GetFullPath, and adds a test demonstrating the fix.

Reported here: https://github.com/xoofx/zio/pull/92#issuecomment-2239530728