### PR TITLE
Reduce allocations in .NET 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Install .NET 8.0
+    - name: Install .NET 9.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Build, Test, Pack, Publish
       if: matrix.os == 'windows-latest'

--- a/src/Zio.Tests/TestSearchPattern.cs
+++ b/src/Zio.Tests/TestSearchPattern.cs
@@ -91,7 +91,7 @@ public class TestSearchPattern
         {
             var searchPattern = "*";
             var search = SearchPattern.Parse(ref path, ref searchPattern);
-            Assert.Throws<ArgumentNullException>(() => search.Match(null));
+            Assert.Throws<ArgumentNullException>(() => search.Match(((string)null)!));
         }
     }
 

--- a/src/Zio.Tests/TestUPath.cs
+++ b/src/Zio.Tests/TestUPath.cs
@@ -268,6 +268,22 @@ public class TestUPath
     }
 
     [Theory]
+    [InlineData("", "")]
+    [InlineData("/", "")]
+    [InlineData("/a", "/")]
+    [InlineData("/a/b", "/a")]
+    [InlineData("/a/b/c.txt", "/a/b")]
+    [InlineData("a", "")]
+    [InlineData("../a", "..")]
+    [InlineData("../../a/b", "../../a")]
+    public void TestGetDirectoryAsSpan(string path1, string expectedDir)
+    {
+        var path = (UPath)path1;
+        var result = path.GetDirectoryAsSpan().ToString();
+        Assert.Equal(expectedDir, result);
+    }
+
+    [Theory]
     [InlineData("", ".txt", "")]
     [InlineData("/", ".txt", "/.txt")]
     [InlineData("/a", ".txt", "/a.txt")]
@@ -322,6 +338,34 @@ public class TestUPath
         Assert.Equal(new List<string>() { "a" }, ((UPath)"a").Split());
         Assert.Equal(new List<string>() { "a", "b" }, ((UPath)"a/b").Split());
         Assert.Equal(new List<string>() { "a", "b", "c" }, ((UPath)"a/b/c").Split());
+    }
+
+    [Fact]
+    public void TestSplitSpan()
+    {
+        Assert.Equal(new List<string>(), ToList((UPath)""));
+        Assert.Equal(new List<string>(), ToList((UPath)"/"));
+        Assert.Equal(new List<string>() { "a" }, ToList((UPath)"/a"));
+        Assert.Equal(new List<string>() {"a", "b", "c"}, ToList((UPath) "/a/b/c"));
+        Assert.Equal(new List<string>() { "a" }, ToList((UPath)"a"));
+        Assert.Equal(new List<string>() { "a", "b" }, ToList((UPath)"a/b"));
+        Assert.Equal(new List<string>() { "a", "b", "c" }, ToList((UPath)"a/b/c"));
+        return;
+
+        List<string> ToList(UPath path)
+        {
+            var enumerator = path.SpanSplit();
+            var list = new List<string>(enumerator.Count);
+
+            foreach (var span in enumerator)
+            {
+                list.Add(span.ToString());
+            }
+
+            Assert.Equal(enumerator.Count, list.Count);
+
+            return list;
+        }
     }
 
 

--- a/src/Zio.Tests/Zio.Tests.csproj
+++ b/src/Zio.Tests/Zio.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/src/Zio/SearchPattern.cs
+++ b/src/Zio/SearchPattern.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -41,6 +42,22 @@ public struct SearchPattern
         if (name is null) throw new ArgumentNullException(nameof(name));
         // if _execMatch is null and _regexMatch is null, we have a * match
         return _exactMatch != null ? _exactMatch == name : _regexMatch is null || _regexMatch.IsMatch(name);
+    }
+
+    /// <summary>
+    /// Tries to match the specified path with this instance.
+    /// </summary>
+    /// <param name="name">The path to match.</param>
+    /// <returns><c>true</c> if the path was matched, <c>false</c> otherwise.</returns>
+    public bool Match(ReadOnlySpan<char> name)
+    {
+#if NET7_0_OR_GREATER
+        // if _execMatch is null and _regexMatch is null, we have a * match
+        return _exactMatch != null ? name.SequenceEqual(_exactMatch) : _regexMatch is null || _regexMatch.IsMatch(name);
+#else
+        // Regex.Match(ReadOnlySpan<char>) is only available starting from .NET
+        return Match(name.ToString());
+#endif
     }
 
     /// <summary>

--- a/src/Zio/UPath.cs
+++ b/src/Zio/UPath.cs
@@ -117,6 +117,16 @@ public readonly struct UPath : IEquatable<UPath>, IComparable<UPath>
     }
 
     /// <summary>
+    /// Performs an explicit conversion from <see cref="UPath"/> to <see cref="ReadOnlySpan{Char}"/>.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns>The result as a span of the conversion.</returns>
+    public static explicit operator ReadOnlySpan<char>(UPath path)
+    {
+        return path.FullName.AsSpan();
+    }
+
+    /// <summary>
     /// Combines two paths into a new path.
     /// </summary>
     /// <param name="path1">The first path to combine.</param>
@@ -320,6 +330,15 @@ public readonly struct UPath : IEquatable<UPath>, IComparable<UPath>
     public override string ToString()
     {
         return FullName;
+    }
+
+    /// <summary>
+    /// Creates a new readonly span from this path.
+    /// </summary>
+    /// <returns>A new readonly span from this path.</returns>
+    public ReadOnlySpan<char> AsSpan()
+    {
+        return FullName.AsSpan();
     }
 
     /// <summary>

--- a/src/Zio/UPathComparer.cs
+++ b/src/Zio/UPathComparer.cs
@@ -2,9 +2,14 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Zio;
 
 public class UPathComparer : IComparer<UPath>, IEqualityComparer<UPath>
+#if HAS_ALTERNATEEQUALITYCOMPARER
+    , IAlternateEqualityComparer<ReadOnlySpan<char>, UPath>, IAlternateEqualityComparer<string, UPath>
+#endif
 {
     public static readonly UPathComparer Ordinal = new(StringComparer.Ordinal);
     public static readonly UPathComparer OrdinalIgnoreCase = new(StringComparer.OrdinalIgnoreCase);
@@ -16,6 +21,10 @@ public class UPathComparer : IComparer<UPath>, IEqualityComparer<UPath>
     private UPathComparer(StringComparer comparer)
     {
         _comparer = comparer;
+
+#if HAS_ALTERNATEEQUALITYCOMPARER
+        Debug.Assert(_comparer is IAlternateEqualityComparer<ReadOnlySpan<char>, string>);
+#endif
     }
 
     public int Compare(UPath x, UPath y)
@@ -32,4 +41,36 @@ public class UPathComparer : IComparer<UPath>, IEqualityComparer<UPath>
     {
         return _comparer.GetHashCode(obj.FullName);
     }
+
+#if HAS_ALTERNATEEQUALITYCOMPARER
+    bool IAlternateEqualityComparer<ReadOnlySpan<char>, UPath>.Equals(ReadOnlySpan<char> alternate, UPath other)
+    {
+        return ((IAlternateEqualityComparer<ReadOnlySpan<char>, string>)_comparer).Equals(alternate, other.FullName);
+    }
+
+    int IAlternateEqualityComparer<ReadOnlySpan<char>, UPath>.GetHashCode(ReadOnlySpan<char> alternate)
+    {
+        return ((IAlternateEqualityComparer<ReadOnlySpan<char>, string>)_comparer).GetHashCode(alternate);
+    }
+
+    UPath IAlternateEqualityComparer<ReadOnlySpan<char>, UPath>.Create(ReadOnlySpan<char> alternate)
+    {
+        return ((IAlternateEqualityComparer<ReadOnlySpan<char>, string>)_comparer).Create(alternate);
+    }
+
+    bool IAlternateEqualityComparer<string, UPath>.Equals(string alternate, UPath other)
+    {
+        return _comparer.Equals(alternate, other.FullName);
+    }
+
+    int IAlternateEqualityComparer<string, UPath>.GetHashCode(string alternate)
+    {
+        return _comparer.GetHashCode(alternate);
+    }
+
+    UPath IAlternateEqualityComparer<string, UPath>.Create(string alternate)
+    {
+        return alternate;
+    }
+#endif
 }

--- a/src/Zio/Zio.csproj
+++ b/src/Zio/Zio.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Zio</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net7.0;net9.0</TargetFrameworks>
     <AssemblyName>Zio</AssemblyName>
     <PackageId>Zio</PackageId>
     <PackageTags>filesystem;vfs;VirtualFileSystem;virtual;abstract;directory;files;io;mock</PackageTags>
@@ -13,7 +13,7 @@
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/xoofx/zio</PackageProjectUrl>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
-    <LangVersion>11</LangVersion>
+    <LangVersion>13</LangVersion>
     <!--Add support for sourcelink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -38,6 +38,9 @@
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -46,6 +49,9 @@
     </PackageReference>
     <PackageReference Include="System.IO.Compression.ZipFile">
       <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.6.0</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -57,10 +63,6 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
-    <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE</DefineConstants>
@@ -74,6 +76,12 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE;HAS_NULLABLEANNOTATIONS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0'">
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <DefineConstants>$(AdditionalConstants);NETSTANDARD;HAS_ZIPARCHIVE;HAS_NULLABLEANNOTATIONS;HAS_ALTERNATEEQUALITYCOMPARER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
In .NET 9 it's now possible to get a dictionary value with a `ReadOnlySpan<char>`.

We're using a dictionary with lookup in the following places:

1. ZipArchiveFileSystem - Checking if the parent dictionary exists
2. MemoryFileSystem - When getting the node, we split the path and enumerate through it

In this PR I changed these lookups to a lookup with `ReadOnlySpan<char>`, so we're allocating less memory.

## Project changes
- Added .NET 9 as target framework
- Changed the version to `9.0.100` in global.json
- Added PackageReference to `System.Memory` for .NET Standard and .NET Framework
- Changed lang version to 13, so we can use ref structs.

## New API's
- `UPathExtensions.GetDirectoryAsSpan(this UPath path)` - Gets the dictionary as a span
- `UPathExtensions.SpanSplit(this UPath path)` - Returns an enumerator which returns the sections of the path as span
