### PR TITLE
Fix ZIP external attributes on move actions

### DIFF
--- a/src/Zio.Tests/FileSystems/TestZipArchiveFileSystemCompact.cs
+++ b/src/Zio.Tests/FileSystems/TestZipArchiveFileSystemCompact.cs
@@ -128,6 +128,56 @@ public class TestZipArchiveFileSystemCompact
         Assert.True(fs.FileExists("/dir2/file2.txt"));
     }
 
+#if !NET472
+    [Fact]
+    public void TestDirectoryMoveAttributes()
+    {
+        fs.CreateDirectory("/dir");
+        fs.WriteAllText("/dir/file.txt", "test");
+
+        fs.SetAttributes("/dir", FileAttributes.Temporary);
+        Assert.Equal(FileAttributes.Directory | FileAttributes.Temporary, fs.GetAttributes("/dir"));
+
+        fs.SetAttributes("/dir/file.txt", FileAttributes.Temporary);
+
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/dir/file.txt"));
+
+        fs.MoveDirectory("/dir", "/moved");
+
+        Assert.True(fs.DirectoryExists("/moved"));
+        Assert.Equal(FileAttributes.Directory | FileAttributes.Temporary, fs.GetAttributes("/moved"));
+
+        Assert.True(fs.FileExists("/moved/file.txt"));
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/moved/file.txt"));
+    }
+
+    [Fact]
+    public void TestFileMoveAttributes()
+    {
+        fs.WriteAllText("/file.txt", "test");
+        fs.SetAttributes("/file.txt", FileAttributes.Temporary);
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/file.txt"));
+
+        fs.MoveFile("/file.txt", "/moved.txt");
+
+        Assert.True(fs.FileExists("/moved.txt"));
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/moved.txt"));
+    }
+
+    [Fact]
+    public void TestCopyFileAttributes()
+    {
+        fs.WriteAllText("/file.txt", "test");
+        fs.SetAttributes("/file.txt", FileAttributes.Temporary);
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/file.txt"));
+
+        fs.CopyFile("/file.txt", "/copy.txt", true);
+
+        Assert.True(fs.FileExists("/copy.txt"));
+        Assert.Equal(FileAttributes.Temporary, fs.GetAttributes("/copy.txt"));
+    }
+#endif
+
     [Fact]
     public void TestFile()
     {

--- a/src/Zio/FileSystems/PhysicalFileSystem.cs
+++ b/src/Zio/FileSystems/PhysicalFileSystem.cs
@@ -480,7 +480,7 @@ public class PhysicalFileSystem : FileSystem
             throw NewDirectoryNotFoundException(path);
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         if (isDirectory)
         {
             Directory.CreateSymbolicLink(systemPath, systemPathToTarget);
@@ -535,7 +535,7 @@ public class PhysicalFileSystem : FileSystem
             }
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         var systemResult = isDirectory ? Directory.ResolveLinkTarget(systemPath, true)?.FullName : File.ResolveLinkTarget(systemPath, true)?.FullName;
 #else
         var systemResult = IsOnWindows ? Interop.Windows.GetFinalPathName(systemPath) : Interop.Unix.readlink(systemPath);

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -267,14 +267,18 @@ public class ZipArchiveFileSystem : FileSystem
             using var srcStream = srcEntry.Open();
             srcStream.CopyTo(destStream);
         }
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-        destEntry.ExternalAttributes = srcEntry.ExternalAttributes | (int)FileAttributes.Archive;
-#endif
+        CopyEntryProperties(srcEntry, destEntry, includeLastWriteTime: false);
         TryGetDispatcher()?.RaiseCreated(destPath);
     }
 
     /// <inheritdoc />
     protected override void CreateDirectoryImpl(UPath path)
+    {
+        CreateDirectoryWithoutNotification(path);
+        TryGetDispatcher()?.RaiseCreated(path);
+    }
+
+    private ZipArchiveEntry CreateDirectoryWithoutNotification(UPath path)
     {
         if (FileExistsImpl(path))
         {
@@ -295,8 +299,7 @@ public class ZipArchiveFileSystem : FileSystem
             }
         }
 
-        CreateEntry(path, isDirectory: true);
-        TryGetDispatcher()?.RaiseCreated(path);
+        return CreateEntry(path, isDirectory: true);
     }
 
     /// <inheritdoc />
@@ -653,27 +656,32 @@ public class ZipArchiveFileSystem : FileSystem
             throw FileSystemExceptionHelper.NewDirectoryNotFoundException(srcPath);
         }
 
-        CreateDirectoryImpl(destPath);
+        var rootEntry = CreateDirectoryWithoutNotification(destPath);
         foreach (var internalEntry in entries)
         {
             var entry = internalEntry.Entry;
 
+            ZipArchiveEntry destEntry;
+
             if (entry.FullName.Length == srcDir.Length)
             {
-                RemoveEntry(entry);
-                continue;
+                destEntry = rootEntry;
             }
-
-            var entryName = entry.FullName.Substring(srcDir.Length);
-            var isDirectory = internalEntry.IsDirectory;
-            var destEntry = CreateEntry(UPath.Combine(destPath, entryName), isDirectory: isDirectory);
-
-            if (!isDirectory)
+            else
             {
-                using var entryStream = entry.Open();
-                using var destEntryStream = destEntry.Open();
-                entryStream.CopyTo(destEntryStream);
+                var entryName = entry.FullName.Substring(srcDir.Length);
+                var isDirectory = internalEntry.IsDirectory;
+                destEntry = CreateEntry(UPath.Combine(destPath, entryName), isDirectory: isDirectory);
+
+                if (!isDirectory)
+                {
+                    using var entryStream = entry.Open();
+                    using var destEntryStream = destEntry.Open();
+                    entryStream.CopyTo(destEntryStream);
+                }
             }
+
+            CopyEntryProperties(entry, destEntry);
 
             TryGetDispatcher()?.RaiseCreated(destPath);
             RemoveEntry(entry);
@@ -717,6 +725,7 @@ public class ZipArchiveFileSystem : FileSystem
         }        
 
         destEntry = CreateEntry(destPath.FullName);
+        CopyEntryProperties(srcEntry, destEntry);
         TryGetDispatcher()?.RaiseCreated(destPath);
         using (var destStream = destEntry.Open())
         {
@@ -827,6 +836,7 @@ public class ZipArchiveFileSystem : FileSystem
             if (!destBackupPath.IsEmpty)
             {
                 var destBackupEntry = CreateEntry(destBackupPath.FullName);
+                CopyEntryProperties(destEntry, destBackupEntry);
                 using var destBackupStream = destBackupEntry.Open();
                 using var destStream = destEntry.Open();
                 destStream.CopyTo(destBackupStream);
@@ -836,6 +846,7 @@ public class ZipArchiveFileSystem : FileSystem
         }
 
         var newEntry = CreateEntry(destPath.FullName);
+        CopyEntryProperties(sourceEntry, newEntry);
         using (var newStream = newEntry.Open())
         {
             using (var sourceStream = sourceEntry.Open())
@@ -985,11 +996,11 @@ public class ZipArchiveFileSystem : FileSystem
         {
             if (ctx.LeadingSlashInArchive)
             {
-                ctx.path.FullName.AsSpan().CopyTo(span.Slice(0, ctx.path.FullName.Length));
+                ctx.path.FullName.AsSpan().CopyTo(span);
             }
             else
             {
-                ctx.path.FullName.AsSpan(1, ctx.path.FullName.Length - 1).CopyTo(span);
+                ctx.path.FullName.AsSpan(1).CopyTo(span);
             }
 
             if (ctx.isDirectory)
@@ -1002,6 +1013,21 @@ public class ZipArchiveFileSystem : FileSystem
     }
 
     private static readonly char[] s_slashChars = { '/', '\\' };
+
+    private static void CopyEntryProperties(ZipArchiveEntry source, ZipArchiveEntry dest, bool includeLastWriteTime = true)
+    {
+        if (includeLastWriteTime)
+        {
+            dest.LastWriteTime = source.LastWriteTime;
+        }
+
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        dest.ExternalAttributes = source.ExternalAttributes;
+#endif
+#if NET6_0_OR_GREATER
+        dest.Comment = source.Comment;
+#endif
+    }
 
     private static ReadOnlySpan<char> GetName(ZipArchiveEntry entry)
     {

--- a/src/Zio/FileSystems/ZipArchiveFileSystem.cs
+++ b/src/Zio/FileSystems/ZipArchiveFileSystem.cs
@@ -246,7 +246,7 @@ public class ZipArchiveFileSystem : FileSystem
         var destEntry = GetEntry(destPath);
         if (destEntry != null)
         {
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             if ((destEntry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
             {
                 throw new UnauthorizedAccessException("Destination file is read only");
@@ -369,7 +369,7 @@ public class ZipArchiveFileSystem : FileSystem
                     }
                 }
             }
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             // check if there are none readonly entries
             foreach (var entry in entries)
             {
@@ -417,7 +417,7 @@ public class ZipArchiveFileSystem : FileSystem
         {
             return;
         }
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         if ((entry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
         {
             throw new UnauthorizedAccessException("Cannot delete file with readonly attribute");
@@ -559,7 +559,7 @@ public class ZipArchiveFileSystem : FileSystem
 
         var attributes = entry.FullName[entry.FullName.Length - 1] == DirectorySeparator ? FileAttributes.Directory : 0;
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         const FileAttributes validValues = (FileAttributes)0x7FFF /* Up to FileAttributes.Encrypted */ | FileAttributes.IntegrityStream | FileAttributes.NoScrubData;
         var externalAttributes = (FileAttributes)entry.ExternalAttributes & validValues;
 
@@ -787,7 +787,7 @@ public class ZipArchiveFileSystem : FileSystem
             entry = CreateEntry(path.FullName);
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         if ((access == FileAccess.Write || access == FileAccess.ReadWrite) && (entry.ExternalAttributes & (int)FileAttributes.ReadOnly) == (int)FileAttributes.ReadOnly)
         {
             throw new UnauthorizedAccessException("Cannot open a file for writing in a file with readonly attribute.");
@@ -796,7 +796,7 @@ public class ZipArchiveFileSystem : FileSystem
 
         var stream = new ZipEntryStream(share, this, entry);
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         if (access is FileAccess.Write or FileAccess.ReadWrite)
         {
             entry.ExternalAttributes |= (int)FileAttributes.Archive;
@@ -869,7 +869,7 @@ public class ZipArchiveFileSystem : FileSystem
     /// <param name="attributes">A bitwise combination of the enumeration values.</param>
     protected override void SetAttributesImpl(UPath path, FileAttributes attributes)
     {
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         var entry = GetEntry(path);
         if (entry == null)
         {
@@ -1021,10 +1021,10 @@ public class ZipArchiveFileSystem : FileSystem
             dest.LastWriteTime = source.LastWriteTime;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         dest.ExternalAttributes = source.ExternalAttributes;
 #endif
-#if NET6_0_OR_GREATER
+#if NET
         dest.Comment = source.Comment;
 #endif
     }

--- a/src/Zio/Interop.cs
+++ b/src/Zio/Interop.cs
@@ -2,7 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#if !NET7_0_OR_GREATER
+#if !NET
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/Zio/SearchPattern.cs
+++ b/src/Zio/SearchPattern.cs
@@ -51,7 +51,7 @@ public struct SearchPattern
     /// <returns><c>true</c> if the path was matched, <c>false</c> otherwise.</returns>
     public bool Match(ReadOnlySpan<char> name)
     {
-#if NET7_0_OR_GREATER
+#if NET
         // if _execMatch is null and _regexMatch is null, we have a * match
         return _exactMatch != null ? name.SequenceEqual(_exactMatch) : _regexMatch is null || _regexMatch.IsMatch(name);
 #else

--- a/src/Zio/UPath.cs
+++ b/src/Zio/UPath.cs
@@ -147,7 +147,7 @@ public readonly struct UPath : IEquatable<UPath>, IComparable<UPath>
 
         try
         {
-#if NET7_0_OR_GREATER
+#if NET
             return string.Create(path1.FullName.Length + path2.FullName.Length + 1, new KeyValuePair<UPath, UPath>(path1, path2), (span, state) =>
             {
                 var (left, right) = state;
@@ -196,7 +196,7 @@ public readonly struct UPath : IEquatable<UPath>, IComparable<UPath>
             return Combine(path1, result);
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         return string.Create(path1.FullName.Length + path2.FullName.Length + path3.FullName.Length + 2, (path1, path2, path3), (span, state) =>
         {
             var (p1, p2, p3) = state;
@@ -234,7 +234,7 @@ public readonly struct UPath : IEquatable<UPath>, IComparable<UPath>
             return Combine(path1, path2, result);
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         return string.Create(path1.FullName.Length + path2.FullName.Length + path3.FullName.Length + path4.FullName.Length + 3, (path1, path2, path3, path4), (span, state) =>
         {
             var (p1, p2, p3, p4) = state;


### PR DESCRIPTION
Attributes (and other metadata) are not copied to the new ZIP entry during the following actions:

1. Moving files - Last write date, comment
2. Moving directories - Attributes, last write date, comment
2. Replacing files - Attributes, last write date, comment
3. Copying files - Comment

This PR adds proper handling to ensure this does happen.

_Note:_ While comments cannot be set through the FileSystem, any existing comment in an archive will now be preserved.