### PR TITLE
Add SubFileSystem constructor argument for ordinal compare choices

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -421,9 +421,9 @@ If a PhysicalFileSystem override is ever used to resolve case-sensitive filesyst
 
 ```c#
 var fs = new PhysicalFileSystem();
-var subfs = new SubFileSystem(fs, "/mnt/c/Temp", StringComparison.OrdinalIgnoreCase);
+var subfs = new SubFileSystem(fs, "/mnt/c/Temp", owned: true, isCaseSensitive: false);
 
-// With OrdinalIgnoreCase, a delegate path that differs only in the casing of the sub-path prefix
+// With isCaseSensitive: false, a delegate path that differs only in the casing of the sub-path prefix
 // still resolves instead of throwing "not rooted to the subpath": if the delegate reports
 // "/mnt/c/TEMP/Logs/today.txt", the sub filesystem exposes it as "/Logs/today.txt".
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -416,6 +416,21 @@ var subfs = new SubFileSystem(fs, "/mnt/c/Temp");
 subfs.DirectoryCreate("/Test");
 ```
 
+By default `SubFileSystem` matches its sub-path case-sensitively, but has an overload for ignoring case.
+If a PhysicalFileSystem override is ever used to resolve case-sensitive filesystems case-insensitively, the subpath can do a string compare on that PhysicalFileSystem without needing a SubFileSystem override.
+
+```c#
+var fs = new PhysicalFileSystem();
+var subfs = new SubFileSystem(fs, "/mnt/c/Temp", StringComparison.OrdinalIgnoreCase);
+
+// With OrdinalIgnoreCase, a delegate path that differs only in the casing of the sub-path prefix
+// still resolves instead of throwing "not rooted to the subpath": if the delegate reports
+// "/mnt/c/TEMP/Logs/today.txt", the sub filesystem exposes it as "/Logs/today.txt".
+
+// The same case-insensitive directory compare powers that prefix check:
+bool isUnder = ((UPath)"/mnt/c/TEMP").IsInDirectory("/mnt/c/temp", recursive: true, StringComparison.OrdinalIgnoreCase); // true
+```
+
 #### `ReadOnlyFileSystem` 
 
 The readonly filesystem simply allows to expose an existing filesystem as read-only and throws a `System.IO.IOException` on any attempt to use one of the writeable `IFileSystem` methods.

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -252,6 +252,33 @@ public class TestSubFileSystem : TestFileSystemBase
     }
 
     [TestMethod]
+    public void TestWatcherCaseInsensitiveRaisesDifferentlyCasedSubDirectory()
+    {
+        var fs = new TriggerableWatchFileSystem();
+        fs.CreateDirectory("/root/sub");
+
+        // Watching a sub-directory (not the root): the converted event keeps the delegate's casing for the
+        // sub-directory segment, so only ShouldRaiseEventImpl's case-insensitive compare keeps it from being dropped.
+        var subFs = new SubFileSystem(fs, "/root", owned: true, isCaseSensitive: false);
+        var watcher = subFs.Watch("/sub");
+        watcher.IncludeSubdirectories = true;
+        watcher.EnableRaisingEvents = true;
+
+        var waitHandle = new ManualResetEvent(false);
+        watcher.Created += (sender, args) =>
+        {
+            if (args.FullPath == "/Sub/foo.txt")
+            {
+                waitHandle.Set();
+            }
+        };
+
+        fs.LastWatcher.TriggerCreated("/root/Sub/foo.txt");
+
+        Assert.IsTrue(waitHandle.WaitOne(100));
+    }
+
+    [TestMethod]
     public void TestResolvePath()
     {
         var fs = GetCommonMemoryFileSystem();

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -66,6 +66,59 @@ public class TestSubFileSystem : TestFileSystemBase
     }
 
     [TestMethod]
+    public void TestConvertPathFromDelegateIsOrdinalByDefault()
+    {
+        var fs = new MemoryFileSystem();
+        fs.CreateDirectory("/sandbox");
+
+        var subFs = new TestableSubFileSystem(fs, "/sandbox");
+
+        // Matching casing strips the sub path prefix.
+        AssertEx.AreEqual((UPath)"/foo.txt", subFs.ConvertPathFromDelegateForTest("/sandbox/foo.txt"));
+
+        // A differently-cased prefix is not rooted under the default ordinal matching.
+        Assert.Throws<InvalidOperationException>(() => subFs.ConvertPathFromDelegateForTest("/SANDBOX/foo.txt"));
+    }
+
+    [TestMethod]
+    public void TestConvertPathFromDelegateOrdinalIgnoreCase()
+    {
+        var fs = new MemoryFileSystem();
+        fs.CreateDirectory("/sandbox");
+
+        var subFs = new TestableSubFileSystem(fs, "/sandbox", StringComparison.OrdinalIgnoreCase);
+
+        // With case-insensitive matching, a differently-cased delegate prefix is stripped correctly.
+        AssertEx.AreEqual((UPath)"/foo.txt", subFs.ConvertPathFromDelegateForTest("/SANDBOX/foo.txt"));
+    }
+
+    [TestMethod]
+    // Section 4: case-insensitive prefix strip. Assumes the delegate already resolved on-disk casing,
+    // so SubFileSystem is doing string-compare only.
+    [DataRow("/a/b", "/A/B/c.txt", "/c.txt")]
+    [DataRow("/A/B", "/a/b/c.txt", "/c.txt")]
+    [DataRow("/a/b", "/A/B/C/d.txt", "/C/d.txt")]
+    public void TestConvertPathFromDelegateOrdinalIgnoreCasePartialPaths(string subPath, string delegatePath, string expected)
+    {
+        var fs = new MemoryFileSystem();
+        fs.CreateDirectory(subPath);
+
+        var subFs = new TestableSubFileSystem(fs, subPath, StringComparison.OrdinalIgnoreCase);
+        AssertEx.AreEqual((UPath)expected, subFs.ConvertPathFromDelegateForTest(delegatePath));
+    }
+
+    [TestMethod]
+    public void TestOrdinalIgnoreCaseConstructorValidatesDirectoryExists()
+    {
+        var fs = new MemoryFileSystem();
+
+        // The comparisonType overload still requires the sub path to exist in the delegate;
+        // the comparison only affects prefix matching, not the existence check.
+        Assert.Throws<DirectoryNotFoundException>(
+            () => new SubFileSystem(fs, "/missing", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
     public void TestWatcher()
     {
         var fs = GetCommonMemoryFileSystem();
@@ -123,6 +176,61 @@ public class TestSubFileSystem : TestFileSystemBase
         physicalFs.WriteAllText($"{physicalDir}{filePath}", "test");
 
         Assert.IsTrue(waitHandle.WaitOne(100));
+    }
+
+    [TestMethod]
+    [DataRow(StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow(StringComparison.Ordinal, false)]
+    public void TestWatcherOrdinalIgnoreCaseConversion(StringComparison comparisonType, bool shouldRaise)
+    {
+        var fs = new TriggerableWatchFileSystem();
+        fs.CreateDirectory("/sandbox");
+
+        var subFs = new SubFileSystem(fs, "/sandbox", comparisonType);
+        var watcher = subFs.Watch("/");
+        watcher.IncludeSubdirectories = true;
+        watcher.EnableRaisingEvents = true;
+
+        var waitHandle = new ManualResetEvent(false);
+        watcher.Created += (sender, args) =>
+        {
+            if (args.FullPath == "/foo.txt")
+            {
+                waitHandle.Set();
+            }
+        };
+
+        // The delegate emits an event with a differently-cased sub-path prefix.
+        fs.LastWatcher.TriggerCreated("/SANDBOX/foo.txt");
+
+        Assert.AreEqual(shouldRaise, waitHandle.WaitOne(100));
+    }
+
+    [TestMethod]
+    public void TestWatcherOrdinalByDefault()
+    {
+        var fs = new TriggerableWatchFileSystem();
+        fs.CreateDirectory("/sandbox");
+
+        // Default constructor - no comparisonType, so matching is ordinal (case-sensitive).
+        var subFs = new SubFileSystem(fs, "/sandbox");
+        var watcher = subFs.Watch("/");
+        watcher.IncludeSubdirectories = true;
+        watcher.EnableRaisingEvents = true;
+
+        var waitHandle = new ManualResetEvent(false);
+        watcher.Created += (sender, args) =>
+        {
+            if (args.FullPath == "/foo.txt")
+            {
+                waitHandle.Set();
+            }
+        };
+
+        // A differently-cased prefix is not rooted under the default ordinal matching, so it is dropped.
+        fs.LastWatcher.TriggerCreated("/SANDBOX/foo.txt");
+
+        Assert.IsFalse(waitHandle.WaitOne(100));
     }
 
     [TestMethod]
@@ -222,7 +330,42 @@ public class TestSubFileSystem : TestFileSystemBase
         {
         }
 
+        public TestableSubFileSystem(IFileSystem fileSystem, UPath subPath, StringComparison comparisonType)
+            : base(fileSystem, subPath, comparisonType, owned: false)
+        {
+        }
+
         public UPath ConvertPathToDelegateForTest(UPath path) => base.ConvertPathToDelegate(path);
+
+        public UPath ConvertPathFromDelegateForTest(UPath path) => base.ConvertPathFromDelegate(path);
+    }
+
+    /// <summary>
+    /// A memory filesystem whose watcher can be triggered manually with an arbitrary (e.g. differently-cased)
+    /// path, used to drive the <see cref="SubFileSystem"/> watcher conversion in isolation.
+    /// </summary>
+    private sealed class TriggerableWatchFileSystem : MemoryFileSystem
+    {
+        public TriggerableWatcher LastWatcher { get; private set; }
+
+        protected override IFileSystemWatcher WatchImpl(UPath path)
+        {
+            LastWatcher = new TriggerableWatcher(this, path);
+            return LastWatcher;
+        }
+    }
+
+    private sealed class TriggerableWatcher : Zio.FileSystems.FileSystemWatcher
+    {
+        public TriggerableWatcher(IFileSystem fileSystem, UPath path) : base(fileSystem, path)
+        {
+        }
+
+        // Skip the delegate watcher's own event filtering so the triggered event reaches the SubFileSystem watcher under test.
+        protected override bool ShouldRaiseEventImpl(FileChangedEventArgs args) => true;
+
+        public void TriggerCreated(UPath fullPath)
+            => RaiseCreated(new FileChangedEventArgs(FileSystem, WatcherChangeTypes.Created, fullPath));
     }
 }
 

--- a/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
+++ b/src/Zio.Tests/FileSystems/TestSubFileSystem.cs
@@ -41,6 +41,25 @@ public class TestSubFileSystem : TestFileSystemBase
     }
 
     [TestMethod]
+    [DataRow("/addons", "/ADDONS/foo.txt", "/foo.txt")]  // flat:   sfs /addons  <-  pfs /ADDONS
+    [DataRow("/a/b", "/A/B/foo.txt", "/foo.txt")]         // nested:  sfs /a/b     <-  pfs /A/B
+    public void TestBasicCaseInsensitive(string sfsSubPath, string pfsDelegatePath, string expected)
+    {
+        // mirrors TestBasic but it explicitly requests a case-insensitive comparison and checks that the overload
+        // is working as intended
+        var fs = new DifferentlyCasedEnumerateFileSystem(pfsDelegatePath);
+        fs.CreateDirectory(sfsSubPath);
+
+        // Through the public EnumeratePaths surface, a differently-cased delegate (pfs) prefix maps into the sfs view.
+        var subfs = new SubFileSystem(fs, sfsSubPath, owned: true, isCaseSensitive: false);
+        AssertEx.AreEqual((UPath)expected, subfs.EnumeratePaths("/").Single());
+
+        // Without the flag the pfs-cased prefix is unrooted, so the same enumeration throws.
+        var sensitive = new SubFileSystem(fs, sfsSubPath);
+        Assert.Throws<InvalidOperationException>(() => sensitive.EnumeratePaths("/").ToList());
+    }
+
+    [TestMethod]
     public void TestGetOrCreateFileSystem()
     {
         var fs = new MemoryFileSystem();
@@ -66,56 +85,46 @@ public class TestSubFileSystem : TestFileSystemBase
     }
 
     [TestMethod]
-    public void TestConvertPathFromDelegateIsOrdinalByDefault()
+    [DataRow("/sandbox", "/sandbox/foo.txt", "/foo.txt", "/SANDBOX/foo.txt", true)]   // flat, sensitive
+    [DataRow("/sandbox", "/sandbox/foo.txt", "/foo.txt", "/SANDBOX/foo.txt", false)]  // flat, insensitive
+    [DataRow("/a/b", "/a/b/c.txt", "/c.txt", "/A/B/c.txt", true)]                     // nested, sensitive
+    [DataRow("/a/b", "/a/b/c.txt", "/c.txt", "/A/B/c.txt", false)]                    // nested, insensitive
+    [DataRow("/A/B", "/A/B/c.txt", "/c.txt", "/a/b/c.txt", false)]                    // upper-cased sub path
+    [DataRow("/a/b", "/a/b/C/d.txt", "/C/d.txt", "/A/B/C/d.txt", false)]              // deeper, child casing preserved
+    public void TestConvertPathFromDelegateRespectsCaseSensitivity(string subPath, string delegatePath, string expected, string differentlyCasedPath, bool isCaseSensitive)
     {
-        var fs = new MemoryFileSystem();
-        fs.CreateDirectory("/sandbox");
-
-        var subFs = new TestableSubFileSystem(fs, "/sandbox");
-
-        // Matching casing strips the sub path prefix.
-        AssertEx.AreEqual((UPath)"/foo.txt", subFs.ConvertPathFromDelegateForTest("/sandbox/foo.txt"));
-
-        // A differently-cased prefix is not rooted under the default ordinal matching.
-        Assert.Throws<InvalidOperationException>(() => subFs.ConvertPathFromDelegateForTest("/SANDBOX/foo.txt"));
-    }
-
-    [TestMethod]
-    public void TestConvertPathFromDelegateOrdinalIgnoreCase()
-    {
-        var fs = new MemoryFileSystem();
-        fs.CreateDirectory("/sandbox");
-
-        var subFs = new TestableSubFileSystem(fs, "/sandbox", StringComparison.OrdinalIgnoreCase);
-
-        // With case-insensitive matching, a differently-cased delegate prefix is stripped correctly.
-        AssertEx.AreEqual((UPath)"/foo.txt", subFs.ConvertPathFromDelegateForTest("/SANDBOX/foo.txt"));
-    }
-
-    [TestMethod]
-    // Section 4: case-insensitive prefix strip. Assumes the delegate already resolved on-disk casing,
-    // so SubFileSystem is doing string-compare only.
-    [DataRow("/a/b", "/A/B/c.txt", "/c.txt")]
-    [DataRow("/A/B", "/a/b/c.txt", "/c.txt")]
-    [DataRow("/a/b", "/A/B/C/d.txt", "/C/d.txt")]
-    public void TestConvertPathFromDelegateOrdinalIgnoreCasePartialPaths(string subPath, string delegatePath, string expected)
-    {
+        // this is ConvertPathFromDelegate overload test to make sure it behaves as expected
         var fs = new MemoryFileSystem();
         fs.CreateDirectory(subPath);
 
-        var subFs = new TestableSubFileSystem(fs, subPath, StringComparison.OrdinalIgnoreCase);
+        var subFs = new TestableSubFileSystem(fs, subPath, isCaseSensitive);
+
+        // Matching casing always strips the sub path prefix.
         AssertEx.AreEqual((UPath)expected, subFs.ConvertPathFromDelegateForTest(delegatePath));
+
+        // A differently-cased prefix strips only when case-insensitive, otherwise it is unrooted and throws.
+        if (isCaseSensitive)
+        {
+            Assert.Throws<InvalidOperationException>(() => subFs.ConvertPathFromDelegateForTest(differentlyCasedPath));
+        }
+        else
+        {
+            AssertEx.AreEqual((UPath)expected, subFs.ConvertPathFromDelegateForTest(differentlyCasedPath));
+        }
     }
 
     [TestMethod]
-    public void TestOrdinalIgnoreCaseConstructorValidatesDirectoryExists()
+    [DataRow("/sandbox", "/SANDBOX/foo.txt")]  // flat
+    [DataRow("/a/b", "/A/B/c.txt")]            // nested
+    public void TestConvertPathFromDelegateIsCaseSensitiveByDefault(string subPath, string differentlyCasedPath)
     {
+        // this is the base ConvertPathFromDelegate that defaults to case-sensitive without overload argument
         var fs = new MemoryFileSystem();
+        fs.CreateDirectory(subPath);
 
-        // The comparisonType overload still requires the sub path to exist in the delegate;
-        // the comparison only affects prefix matching, not the existence check.
-        Assert.Throws<DirectoryNotFoundException>(
-            () => new SubFileSystem(fs, "/missing", StringComparison.OrdinalIgnoreCase));
+        // The flag-less constructor defaults to case-sensitive, so a differently-cased prefix is unrooted and throws.
+        var subFs = new TestableSubFileSystem(fs, subPath);
+        Assert.Throws<InvalidOperationException>(() => subFs.ConvertPathFromDelegateForTest(differentlyCasedPath));
     }
 
     [TestMethod]
@@ -179,14 +188,21 @@ public class TestSubFileSystem : TestFileSystemBase
     }
 
     [TestMethod]
-    [DataRow(StringComparison.OrdinalIgnoreCase, true)]
-    [DataRow(StringComparison.Ordinal, false)]
-    public void TestWatcherOrdinalIgnoreCaseConversion(StringComparison comparisonType, bool shouldRaise)
+    [DataRow("/test", "/test", "/foo.txt")]
+    [DataRow("/test", "/test", "/~foo.txt")]
+    [DataRow("/test", "/TEST", "/foo.txt")]
+    [DataRow("/test", "/TEST", "/~foo.txt")]
+    [DataRow("/verylongname", "/VERYLONGNAME", "/foo.txt")]
+    [DataRow("/verylongname", "/VERYLONGNAME", "/~foo.txt")]
+    public void TestWatcherCaseInsensitive(string eventDir, string subDir, string filePath)
     {
+        // This mirrors TestWatcherCaseSensitive, but checks that the watcher can also make
+        // a case-insensitive comparison as well, when constructor initializes case-insensitive
         var fs = new TriggerableWatchFileSystem();
-        fs.CreateDirectory("/sandbox");
+        fs.CreateDirectory(subDir);
 
-        var subFs = new SubFileSystem(fs, "/sandbox", comparisonType);
+        // Case-insensitive: a differently-cased sub-path prefix on the delegate event still matches.
+        var subFs = new SubFileSystem(fs, subDir, owned: true, isCaseSensitive: false);
         var watcher = subFs.Watch("/");
         watcher.IncludeSubdirectories = true;
         watcher.EnableRaisingEvents = true;
@@ -194,25 +210,28 @@ public class TestSubFileSystem : TestFileSystemBase
         var waitHandle = new ManualResetEvent(false);
         watcher.Created += (sender, args) =>
         {
-            if (args.FullPath == "/foo.txt")
+            if (args.FullPath == filePath)
             {
                 waitHandle.Set();
             }
         };
 
-        // The delegate emits an event with a differently-cased sub-path prefix.
-        fs.LastWatcher.TriggerCreated("/SANDBOX/foo.txt");
+        // The delegate emits an event whose prefix casing may differ from the sub path.
+        fs.LastWatcher.TriggerCreated($"{eventDir}{filePath}");
 
-        Assert.AreEqual(shouldRaise, waitHandle.WaitOne(100));
+        Assert.IsTrue(waitHandle.WaitOne(100));
     }
 
     [TestMethod]
-    public void TestWatcherOrdinalByDefault()
+    public void TestWatcherCaseSensitiveDropsDifferentCasing()
     {
+        // Since we now have an override for ShouldRaiseEventImpl, we want to make sure a
+        // non-overloaded SubFileSystem will still behave case-sensitively
         var fs = new TriggerableWatchFileSystem();
         fs.CreateDirectory("/sandbox");
 
-        // Default constructor - no comparisonType, so matching is ordinal (case-sensitive).
+        // Default constructor is ordinal (case-sensitive): a differently-cased event prefix is out of
+        // scope, so the watcher drops it (guards the filtering / negative branch that the raise tests don't).
         var subFs = new SubFileSystem(fs, "/sandbox");
         var watcher = subFs.Watch("/");
         watcher.IncludeSubdirectories = true;
@@ -227,7 +246,6 @@ public class TestSubFileSystem : TestFileSystemBase
             }
         };
 
-        // A differently-cased prefix is not rooted under the default ordinal matching, so it is dropped.
         fs.LastWatcher.TriggerCreated("/SANDBOX/foo.txt");
 
         Assert.IsFalse(waitHandle.WaitOne(100));
@@ -330,8 +348,8 @@ public class TestSubFileSystem : TestFileSystemBase
         {
         }
 
-        public TestableSubFileSystem(IFileSystem fileSystem, UPath subPath, StringComparison comparisonType)
-            : base(fileSystem, subPath, comparisonType, owned: false)
+        public TestableSubFileSystem(IFileSystem fileSystem, UPath subPath, bool isCaseSensitive)
+            : base(fileSystem, subPath, owned: false, isCaseSensitive: isCaseSensitive)
         {
         }
 
@@ -340,10 +358,20 @@ public class TestSubFileSystem : TestFileSystemBase
         public UPath ConvertPathFromDelegateForTest(UPath path) => base.ConvertPathFromDelegate(path);
     }
 
-    /// <summary>
-    /// A memory filesystem whose watcher can be triggered manually with an arbitrary (e.g. differently-cased)
-    /// path, used to drive the <see cref="SubFileSystem"/> watcher conversion in isolation.
-    /// </summary>
+    // Fake delegate that always enumerates one caller-supplied path, so SubFileSystem's enumerate conversion sees a differently-cased prefix.
+    private sealed class DifferentlyCasedEnumerateFileSystem : MemoryFileSystem
+    {
+        private readonly UPath _delegatePath;
+
+        public DifferentlyCasedEnumerateFileSystem(UPath delegatePath) => _delegatePath = delegatePath;
+
+        protected override IEnumerable<UPath> EnumeratePathsImpl(UPath path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
+        {
+            yield return _delegatePath;
+        }
+    }
+
+    // Fake delegate that exposes its watcher via LastWatcher, so a test can fire an arbitrary (differently-cased) event into SubFileSystem.
     private sealed class TriggerableWatchFileSystem : MemoryFileSystem
     {
         public TriggerableWatcher LastWatcher { get; private set; }
@@ -355,13 +383,13 @@ public class TestSubFileSystem : TestFileSystemBase
         }
     }
 
+    // Pokeable watcher: TriggerCreated exposes the protected RaiseCreated, and it skips its own filtering so events reach the SubFileSystem watcher under test.
     private sealed class TriggerableWatcher : Zio.FileSystems.FileSystemWatcher
     {
         public TriggerableWatcher(IFileSystem fileSystem, UPath path) : base(fileSystem, path)
         {
         }
 
-        // Skip the delegate watcher's own event filtering so the triggered event reaches the SubFileSystem watcher under test.
         protected override bool ShouldRaiseEventImpl(FileChangedEventArgs args) => true;
 
         public void TriggerCreated(UPath fullPath)

--- a/src/Zio.Tests/TestFilterPattern.cs
+++ b/src/Zio.Tests/TestFilterPattern.cs
@@ -42,6 +42,21 @@ public class TestFilterPattern
         var filter = FilterPattern.Parse(filterPattern);
         AssertEx.AreEqual(match, filter.Match(fileName));
     }
+
+    [TestMethod]
+    // Filter globs should match case-insensitively (sbox.txt should match Sbox.txt / sbox.TXT / SBOX.txt).
+    // Skipped: FilterPattern is currently case-sensitive. Remove the Skip once a follow-up PR adds
+    // case-insensitive matching, and this should pass.
+    [DataRow("Sbox.txt", "sbox.txt")]
+    [DataRow("sbox.TXT", "sbox.txt")]
+    [DataRow("SBOX.txt", "sbox.txt")]
+    public void TestMatchOrdinalIgnoreCase(string fileName, string filterPattern)
+    {
+        Skip.If(true, "FilterPattern case-insensitive matching pending a follow-up PR.");
+
+        var filter = FilterPattern.Parse(filterPattern);
+        Assert.IsTrue(filter.Match(fileName));
+    }
 }
 
 

--- a/src/Zio.Tests/TestUPath.cs
+++ b/src/Zio.Tests/TestUPath.cs
@@ -331,6 +331,34 @@ public class TestUPath
     }
 
     [TestMethod]
+    // Case-insensitive matches that ordinal rejects
+    [DataRow("/A/b", "/a", true, StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow("/A/b", "/a", true, StringComparison.Ordinal, false)]
+
+    // Exact match with different casing
+    [DataRow("/FOO", "/foo", true, StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow("/FOO", "/foo", true, StringComparison.Ordinal, false)]
+
+    // Boundary: not a real child regardless of comparison
+    [DataRow("/foobar", "/foo", true, StringComparison.OrdinalIgnoreCase, false)]
+    [DataRow("/FOOBAR", "/foo", true, StringComparison.OrdinalIgnoreCase, false)]
+
+    // Non-recursive honors the comparison too
+    [DataRow("/A/b", "/a", false, StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow("/A/b/c", "/a", false, StringComparison.OrdinalIgnoreCase, false)]
+
+    // Multi-segment case variants (dataset: /a/b/c vs /A/B/C)
+    [DataRow("/A/B/C", "/a/b/c", true, StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow("/a/b/c", "/A/B/C", true, StringComparison.OrdinalIgnoreCase, true)]
+    [DataRow("/A/B/C", "/a/b/c", true, StringComparison.Ordinal, false)]
+    public void TestIsInDirectoryWithComparison(string path1, string directory, bool recursive, StringComparison comparisonType, bool expected)
+    {
+        var path = (UPath)path1;
+        var result = path.IsInDirectory(directory, recursive, comparisonType);
+        AssertEx.AreEqual(expected, result);
+    }
+
+    [TestMethod]
     public void TestSplit()
     {
         AssertEx.AreEqual(new List<string>(), ((UPath)"").Split());

--- a/src/Zio/FileSystems/SubFileSystem.cs
+++ b/src/Zio/FileSystems/SubFileSystem.cs
@@ -15,6 +15,8 @@ namespace Zio.FileSystems;
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "(),nq}")]
 public class SubFileSystem : ComposeFileSystem
 {
+    private readonly StringComparison _comparisonType = StringComparison.Ordinal;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SubFileSystem"/> class.
     /// </summary>
@@ -29,6 +31,20 @@ public class SubFileSystem : ComposeFileSystem
         {
             throw NewDirectoryNotFoundException(SubPath);
         }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubFileSystem"/> class with a case sensitivity option.
+    /// </summary>
+    /// <param name="fileSystem">The file system to create a view from.</param>
+    /// <param name="subPath">The sub path view to create filesystem.</param>
+    /// <param name="comparisonType">Specifies how the sub path prefix is matched (<see cref="StringComparison.Ordinal"/> by default)</param>
+    /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
+    /// <exception cref="DirectoryNotFoundException">If the directory subPath does not exist in the delegate FileSystem</exception>
+    public SubFileSystem(IFileSystem fileSystem, UPath subPath, StringComparison comparisonType, bool owned = true)
+    : this(fileSystem, subPath, owned)
+    {
+        _comparisonType = comparisonType;
     }
 
     /// <summary>
@@ -60,13 +76,16 @@ public class SubFileSystem : ComposeFileSystem
 
         protected override UPath? TryConvertPath(UPath pathFromEvent)
         {
-            if (!pathFromEvent.IsInDirectory(_fileSystem.SubPath, true))
+            if (!pathFromEvent.IsInDirectory(_fileSystem.SubPath, true, _fileSystem._comparisonType))
             {
                 return null;
             }
 
             return _fileSystem.ConvertPathFromDelegate(pathFromEvent);
         }
+
+        protected override bool ShouldRaiseEventImpl(FileChangedEventArgs args)
+            => args.FullPath.IsInDirectory(Path, IncludeSubdirectories, _fileSystem._comparisonType);
     }
 
     /// <inheritdoc />
@@ -74,7 +93,7 @@ public class SubFileSystem : ComposeFileSystem
     {
         var safePath = path.ToRelative();
         var delegatePath = SubPath / safePath;
-        if (delegatePath != SubPath && !delegatePath.IsInDirectory(SubPath, true))
+        if (delegatePath != SubPath && !delegatePath.IsInDirectory(SubPath, true)) // stays ordinal, casing has to match
         {
             throw new UnauthorizedAccessException($"The path `{path}` escapes the sub filesystem root `{SubPath}`");
         }
@@ -86,7 +105,7 @@ public class SubFileSystem : ComposeFileSystem
     protected override UPath ConvertPathFromDelegate(UPath path)
     {
         var fullPath = path.FullName;
-        if (!fullPath.StartsWith(SubPath.FullName, StringComparison.Ordinal) || (fullPath.Length > SubPath.FullName.Length && fullPath[SubPath.FullName.Length] != UPath.DirectorySeparator))
+        if (!fullPath.StartsWith(SubPath.FullName, _comparisonType) || (fullPath.Length > SubPath.FullName.Length && fullPath[SubPath.FullName.Length] != UPath.DirectorySeparator))
         {
             // More a safe guard, as it should never happen, but if a delegate filesystem doesn't respect its root path
             // we are throwing an exception here

--- a/src/Zio/FileSystems/SubFileSystem.cs
+++ b/src/Zio/FileSystems/SubFileSystem.cs
@@ -15,7 +15,7 @@ namespace Zio.FileSystems;
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "(),nq}")]
 public class SubFileSystem : ComposeFileSystem
 {
-    private readonly StringComparison _comparisonType = StringComparison.Ordinal;
+    private readonly StringComparison _comparisonType;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SubFileSystem"/> class.
@@ -24,13 +24,9 @@ public class SubFileSystem : ComposeFileSystem
     /// <param name="subPath">The sub path view to create filesystem.</param>
     /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
     /// <exception cref="DirectoryNotFoundException">If the directory subPath does not exist in the delegate FileSystem</exception>
-    public SubFileSystem(IFileSystem fileSystem, UPath subPath, bool owned = true) : base(fileSystem, owned)
+    public SubFileSystem(IFileSystem fileSystem, UPath subPath, bool owned = true)
+    : this(fileSystem, subPath, owned, true) // case sensitive always true by default
     {
-        SubPath = subPath.AssertAbsolute(nameof(subPath));
-        if (!fileSystem.DirectoryExists(SubPath))
-        {
-            throw NewDirectoryNotFoundException(SubPath);
-        }
     }
 
     /// <summary>
@@ -38,13 +34,18 @@ public class SubFileSystem : ComposeFileSystem
     /// </summary>
     /// <param name="fileSystem">The file system to create a view from.</param>
     /// <param name="subPath">The sub path view to create filesystem.</param>
-    /// <param name="comparisonType">Specifies how the sub path prefix is matched (<see cref="StringComparison.Ordinal"/> by default)</param>
     /// <param name="owned">True if <paramref name="fileSystem"/> should be disposed when this instance is disposed.</param>
+    /// <param name="isCaseSensitive">Specifies if paths should be compared against the sub path case-sensitively.</param>
     /// <exception cref="DirectoryNotFoundException">If the directory subPath does not exist in the delegate FileSystem</exception>
-    public SubFileSystem(IFileSystem fileSystem, UPath subPath, StringComparison comparisonType, bool owned = true)
-    : this(fileSystem, subPath, owned)
+    public SubFileSystem(IFileSystem fileSystem, UPath subPath, bool owned, bool isCaseSensitive)
+    : base(fileSystem, owned)
     {
-        _comparisonType = comparisonType;
+        SubPath = subPath.AssertAbsolute(nameof(subPath));
+        _comparisonType = isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        if (!fileSystem.DirectoryExists(SubPath))
+        {
+            throw NewDirectoryNotFoundException(SubPath);
+        }
     }
 
     /// <summary>
@@ -93,7 +94,7 @@ public class SubFileSystem : ComposeFileSystem
     {
         var safePath = path.ToRelative();
         var delegatePath = SubPath / safePath;
-        if (delegatePath != SubPath && !delegatePath.IsInDirectory(SubPath, true)) // stays ordinal, casing has to match
+        if (delegatePath != SubPath && !delegatePath.IsInDirectory(SubPath, true)) // stays case-sensitive, casing already matches by construction
         {
             throw new UnauthorizedAccessException($"The path `{path}` escapes the sub filesystem root `{SubPath}`");
         }

--- a/src/Zio/UPathExtensions.cs
+++ b/src/Zio/UPathExtensions.cs
@@ -290,7 +290,17 @@ public static class UPathExtensions
     /// <param name="directory">The directory to check the path against.</param>
     /// <param name="recursive">True to check if it is anywhere in the directory, false to check if it is directly in the directory.</param>
     /// <returns>True when the path is in the given directory.</returns>
-    public static bool IsInDirectory(this UPath path, UPath directory, bool recursive)
+    public static bool IsInDirectory(this UPath path, UPath directory, bool recursive) => path.IsInDirectory(directory, recursive, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Checks if the path is in the given directory. Does not check if the paths exist.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <param name="directory">The directory to check the path against.</param>
+    /// <param name="recursive">True to check if it is anywhere in the directory, false to check if it is directly in the directory.</param>
+    /// <param name="comparisonType">The string comparison used to match the directory prefix (e.g. <see cref="StringComparison.Ordinal"/>, the default used by the other overload).</param>
+    /// <returns>True when the path is in the given directory.</returns>
+    public static bool IsInDirectory(this UPath path, UPath directory, bool recursive, StringComparison comparisonType)
     {
         path.AssertNotNull();
         directory.AssertNotNull(nameof(directory));
@@ -303,7 +313,7 @@ public static class UPathExtensions
         var target = path.FullName;
         var dir = directory.FullName;
 
-        if (target.Length < dir.Length || !target.StartsWith(dir, StringComparison.Ordinal))
+        if (target.Length < dir.Length || !target.StartsWith(dir, comparisonType))
         {
             return false;
         }


### PR DESCRIPTION
For issue https://github.com/xoofx/zio/issues/105

Kind of new to submitting PRs but I tried my best to stage this well (emerging college student). 

Add a SubFileSystem overload to allow ordinal compare to be chosen without needing an inherited class.
That way I can do `new SubFileSystem( system, path, StringComparison.OrdinalIgnoreCase, false )` instead of
overriding ConvertPathFromDelegate.

I also created an overload for `UPathExtensions.IsInDirectory` so that the decided ordinal can resolve the same way,
otherwise when a path is checked in a given directory it may return false even if `ConvertPathFromDelegate` is true.

FileSystemWatcher's `ShouldRaiseEventImpl` returns args.FullPath.IsInDirectory(Path, IncludeSubdirectories), by default, so I included a small override that is the same thing but with the ordinal choice.

I added new tests for to make sure ordinal still works by default and can be overriden to use the new string compare. There is also a skipped test for FilterPattern because that also is case-insensitive by default when comparing globs, but that's a separate PR for a separate day.

Am I headed in the right direction?

